### PR TITLE
small meta.yaml updates

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: fre
+  name: fre-cli
   version: 0.1.0
 
 source:
@@ -18,6 +18,8 @@ requirements:
   run:
     - python
     - click
+    - pyyaml
+    - jsonschema
 
 test:
   imports:


### PR DESCRIPTION
Add pyyaml and jsonschema as conda prereqs, and change package name to fre-cli.

The tools will still be available as fre (fre --help).