### PR TITLE
Install metomi-rose pip prerequisites.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         'Click',
         'pyyaml',
         'jsonschema',
+        'metomi-rose',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
To help developers install fre-cli without conda.