### PR TITLE
Add cylc to conda dependencies

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -29,6 +29,9 @@ requirements:
     - jsonschema
     - noaa-gfdl::intakebuilder
     - conda-forge::metomi-rose
+    - cylc-flow
+    - cylc-rose
+    - metomi-rose
 
 test:
   imports:


### PR DESCRIPTION
Various fre pp tools use cylc, and currently it is module loaded at GFDL.

This change would allow the fre pp tools to work at non-GFDL sites and generally easily, at the cost of a larger conda install.