### PR TITLE
61.branch.clone

### DIFF
--- a/fre/fre.py
+++ b/fre/fre.py
@@ -314,8 +314,17 @@ def configure(context, y):
                 type=str, 
                 help="Target name", 
                 required=True)
+@click.option("-b", 
+              "--branch",
+              show_default=True,
+              default="main",
+              type=str,
+              help=" ".join(["Name of fre2/workflows/postproc branch to clone;" 
+                            "defaults to 'main'. Not intended for production use,"
+                            "but needed for branch testing."])
+                            )
 @click.pass_context
-def checkout(context, experiment, platform, target):
+def checkout(context, experiment, platform, target, branch='main'):
     """ - Execute fre pp checkout """
     context.forward(frepp.frepp.checkout)
 

--- a/fre/frepp/checkoutScript.py
+++ b/fre/frepp/checkoutScript.py
@@ -58,6 +58,17 @@ def checkoutTemplate(experiment, platform, target, branch='main'):
     clonecmd = f"git clone -b {branch} --single-branch --depth=1 --recursive https://gitlab.gfdl.noaa.gov/fre2/workflows/postprocessing.git {name}"
     preexist_error = f"fatal: destination path '{name}' already exists and is not an empty directory."
     cloneproc = subprocess.run(clonecmd, shell=True, check=True, stdout=PIPE, stderr=STDOUT)
+    if not cloneproc.returncode == 0:
+        if re.search(preexist_error.encode('ASCII'),cloneproc.stdout) is not None:
+            argstring = f" -e {experiment} -p {platform} -t {target}"
+            stop_report = "\n".join([f"Error in checkoutTemplate: the workflow definition specified by -e/-p/-t already exists at the location ~/cylc-src/{name}!",
+                                     "Please delete workflow dir and clone again."])
+            click.echo(stop_report)
+            return 1
+        else:
+            click.echo(clonecmd)
+            click.echo(cloneproc.stdout)
+        return 1
 
 #############################################
 

--- a/fre/frepp/checkoutScript.py
+++ b/fre/frepp/checkoutScript.py
@@ -6,7 +6,10 @@
 import os
 from pathlib import Path
 import subprocess
+from subprocess import PIPE
+from subprocess import STDOUT
 import click
+import re
 
 #############################################
 
@@ -30,14 +33,14 @@ package_dir = os.path.dirname(os.path.abspath(__file__))
               type=str, 
               help="Target name", 
               required=True)
-\@click.option("-b", 
+@click.option("-b", 
               "--branch",
               show_default=True,
               default="main",
               type=str,
               help=" ".join(["Name of fre2/workflows/postproc branch to clone;" 
                             "defaults to 'main'. Not intended for production use,"
-                            "but needed for branch testing."])
+                            "but needed for branch testing."]))
                             
 def checkoutTemplate(experiment, platform, target, branch='main'):
     """
@@ -57,7 +60,7 @@ def checkoutTemplate(experiment, platform, target, branch='main'):
     click.echo("cloning experiment into directory " + directory + "/" + name)
     clonecmd = f"git clone -b {branch} --single-branch --depth=1 --recursive https://gitlab.gfdl.noaa.gov/fre2/workflows/postprocessing.git {name}"
     preexist_error = f"fatal: destination path '{name}' already exists and is not an empty directory."
-    cloneproc = subprocess.run(clonecmd, shell=True, check=True, stdout=PIPE, stderr=STDOUT)
+    cloneproc = subprocess.run(clonecmd, shell=True, check=False, stdout=PIPE, stderr=STDOUT)
     if not cloneproc.returncode == 0:
         if re.search(preexist_error.encode('ASCII'),cloneproc.stdout) is not None:
             argstring = f" -e {experiment} -p {platform} -t {target}"
@@ -66,6 +69,7 @@ def checkoutTemplate(experiment, platform, target, branch='main'):
             click.echo(stop_report)
             return 1
         else:
+            click.echo(preexist_error)
             click.echo(clonecmd)
             click.echo(cloneproc.stdout)
         return 1

--- a/fre/frepp/checkoutScript.py
+++ b/fre/frepp/checkoutScript.py
@@ -30,9 +30,18 @@ package_dir = os.path.dirname(os.path.abspath(__file__))
               type=str, 
               help="Target name", 
               required=True)
-def checkoutTemplate(experiment, platform, target):
+\@click.option("-b", 
+              "--branch",
+              show_default=True,
+              default="main",
+              type=str,
+              help=" ".join(["Name of fre2/workflows/postproc branch to clone;" 
+                            "defaults to 'main'. Not intended for production use,"
+                            "but needed for branch testing."])
+                            
+def checkoutTemplate(experiment, platform, target, branch='main'):
     """
-    Checkout the template file
+    Checkout the workflow template files from the repo
     """
     # Create the directory if it doesn't exist
     directory = os.path.expanduser("~/cylc-src")
@@ -44,10 +53,11 @@ def checkoutTemplate(experiment, platform, target):
     # Set the name of the directory
     name = f"{experiment}__{platform}__{target}"
 
-    # Clone the repository with depth=1
-    click.echo("cloning into directory " + directory + "/" + name)
-    clonecmd = f"git clone --depth=1 --recursive https://gitlab.gfdl.noaa.gov/fre2/workflows/postprocessing.git {name}"
-    subprocess.run(clonecmd, shell=True, check=True)
+    # Clone the repository with depth=1; check for errors
+    click.echo("cloning experiment into directory " + directory + "/" + name)
+    clonecmd = f"git clone -b {branch} --single-branch --depth=1 --recursive https://gitlab.gfdl.noaa.gov/fre2/workflows/postprocessing.git {name}"
+    preexist_error = f"fatal: destination path '{name}' already exists and is not an empty directory."
+    cloneproc = subprocess.run(clonecmd, shell=True, check=True, stdout=PIPE, stderr=STDOUT)
 
 #############################################
 

--- a/fre/frepp/frepp.py
+++ b/fre/frepp/frepp.py
@@ -83,10 +83,19 @@ def configureYAML(context, y):
               type=str, 
               help="Target name", 
               required=True)
+@click.option("-b", 
+              "--branch",
+              show_default=True,
+              default="main",
+              type=str,
+              help=" ".join(["Name of fre2/workflows/postproc branch to clone;" 
+                            "defaults to 'main'. Not intended for production use,"
+                            "but needed for branch testing."])
+                            )
 @click.pass_context
-def checkout(context, experiment, platform, target):
+def checkout(context, experiment, platform, target, branch='main'):
     """
-    Checkout the template file
+    Checkout the workflow template files from the repo
     """
     context.forward(checkoutTemplate)
 


### PR DESCRIPTION
- Updated --help in fre, frepp, checkoutScript; if it's too long, I can shorten
- Slightly clearer errors on checkoutScript for the git clone
- CheckoutScript: more imports, slightly changed format of the subprocess command for error-checking within the script rather than exiting

Scripted tests: /home/cew/Code/fre-features/fre2_branch_clone/test_fre2_branch_clone.bash