### PR TITLE
 Fix grid value name for remap and regrid rose apps (for now)

### DIFF
--- a/fre/pp/configureScriptYAML.py
+++ b/fre/pp/configureScriptYAML.py
@@ -132,9 +132,9 @@ def yamlInfo(yamlfile,experiment,platform,target):
                 if i.get("xyInterp") == None:
                   f.write(f"grid=native\n")
                 #in xyInterp exists, component can be regridded
-                elif i.get("xyInterp") != None and i.get("xyInterp") == y["define5"]:
+                elif i.get("xyInterp") != None and i.get("xyInterp") == y["defaultxyInterp"]:
                   f.write("grid=regrid-xy/default\n") 
-                elif i.get("xyInterp") != None and i.get("xyInterp") != y["define5"]:
+                elif i.get("xyInterp") != None and i.get("xyInterp") != y["defaultxyInterp"]:
                   gridLat=i.get("xyInterp").split(",")[0]
                   gridLon=i.get("xyInterp").split(",")[1]
                   f.write(f"grid=regrid-xy/{gridLat}_{gridLon}\n")
@@ -180,7 +180,7 @@ def yamlInfo(yamlfile,experiment,platform,target):
 
                   f.write("\n")
 
-                if compkey == "xyInterp" and compvalue == y["define5"]:
+                if compkey == "xyInterp" and compvalue == y["defaultxyInterp"]:
                   f.write(f"outputGridType=default\n")
                 elif compkey == "xyInterp": 
                   gridLat=compvalue.split(",")[0]

--- a/fre/pp/configureScriptYAML.py
+++ b/fre/pp/configureScriptYAML.py
@@ -132,10 +132,14 @@ def yamlInfo(yamlfile,experiment,platform,target):
                 if i.get("xyInterp") == None:
                   f.write(f"grid=native\n")
                 #in xyInterp exists, component can be regridded
-                elif i.get("xyInterp") != None:
-                  f.write("grid=regrid-xy\n") 
+                elif i.get("xyInterp") != None and i.get("xyInterp") == y["define5"]:
+                  f.write("grid=regrid-xy/default\n") 
+                elif i.get("xyInterp") != None and i.get("xyInterp") != y["define5"]:
+                  gridLat=i.get("xyInterp").split(",")[0]
+                  gridLon=i.get("xyInterp").split(",")[1]
+                  f.write(f"grid=regrid-xy/{gridLat}_{gridLon}\n")
                 if "static" in compvalue:
-                  f.write("freq=P0Y\n")                       
+                  f.write("freq=P0Y\n") 
               elif compkey == "sources":
                 f.write(f"{compkey}={compvalue} ")
               elif compkey == "timeSeries":

--- a/fre/pp/edits-template.yaml
+++ b/fre/pp/edits-template.yaml
@@ -11,15 +11,15 @@ configuration paths:
 
 # Define widely used variables
 # Length of analysis of experiment, string in double quotes
-define1: &ANA_AMIP_LEN ""
+ana_amip_len: &ANA_AMIP_LEN ""
 # String in double quotes
-define2: &PP_AMIP_CHUNK96 ""
+pp_amip_chunk: &PP_AMIP_CHUNK96 ""
 # Year to start analysis on experiment, string in double quotes
-define3: &ANA_AMIP_START ""
+ana_amip_start: &ANA_AMIP_START ""
 # Year to stop analysis on experiment, string in double quotes
-define4: &ANA_AMIP_STOP ""
+ana_amip_stop: &ANA_AMIP_STOP ""
 # Default xy Interp, string in double quotes
-define5: &defaultxyInterp ""
+defaultyInterp: &defaultxyInterp ""
 
 # Information for rose-suite experiment configuration 
 rose-suite:

--- a/fre/pp/ppyaml_test/pp.yaml
+++ b/fre/pp/ppyaml_test/pp.yaml
@@ -5,11 +5,11 @@ configuration_paths:
   rose-remap: "app/remap-pp-components/rose-app.conf" 
   rose-regrid: "app/regrid-xy/rose-app.conf" 
 
-define1: &ANA_AMIP_LEN "10yr"
-define2: &PP_AMIP_CHUNK96 "1yr"
-define3: &ANA_AMIP_START "1980"
-define4: &ANA_AMIP_STOP "1988"
-define5: &defaultxyInterp "180,288"
+ana_amip_len: &ANA_AMIP_LEN "10yr"
+pp_amip_chunk: &PP_AMIP_CHUNK96 "1yr"
+ana_amip_start: &ANA_AMIP_START "1980"
+ana_amip_stop: &ANA_AMIP_STOP "1988"
+defaultxyInterp: &defaultxyInterp "180,288"
 
 rose-suite:
   settings:

--- a/fre/pp/schema.json
+++ b/fre/pp/schema.json
@@ -11,11 +11,11 @@
         "rose-regrid": {"type": ["string","null"]}
       }
     },
-    "define1": {"type": "string"},
-    "define2": {"type": "string"},
-    "define3": {"type": "string"},
-    "define4": {"type": "string"},
-    "define5": {"type": "string"},
+    "ana_amip_len": {"type": "string"},
+    "pp_amip_chunk": {"type": "string"},
+    "ana_amip_start": {"type": "string"},
+    "ana_amip_stop": {"type": "string"},
+    "defaultxyInterp": {"type": "string"},
 
     "rose-suite": {
       "type": "object",


### PR DESCRIPTION
In the remap-pp-components rewrite, Dana realized the grid value needed to specify default or whatever grid was being used, in the rose-app.conf. This pr is fixing the way `grid` is configured 