### PR TITLE
PP configure-yaml updates

### DIFF
--- a/fre/pp/configure_script_yaml.py
+++ b/fre/pp/configure_script_yaml.py
@@ -99,7 +99,7 @@ def yamlInfo(yamlfile,experiment,platform,target):
         # if xyInterp exists, component can be regridded
         else:
           interp_split = i.get('xyInterp').split(',')
-          rose_remap.set(keys=[f'{comp}', 'grid'], value=f'regrid-xy/{interp_method[1]}_{interp_method[0]}.{interp_method}')
+          rose_remap.set(keys=[f'{comp}', 'grid'], value=f'regrid-xy/{interp_split[0]}_{interp_split[1]}.{interp_method}')
 
         # set regrid items
         if i.get("xyInterp") != None:
@@ -110,7 +110,7 @@ def yamlInfo(yamlfile,experiment,platform,target):
           interp_split = i.get('xyInterp').split(',')
           rose_regrid.set(keys=[f'{comp}', 'outputGridLon'], value=f'{interp_split[1]}')
           rose_regrid.set(keys=[f'{comp}', 'outputGridLat'], value=f'{interp_split[0]}')
-          rose_regrid.set(keys=[f'{comp}', 'outputGridType'], value=f'{interp_method[1]}_{interp_method[0]}.{interp_method}')
+          rose_regrid.set(keys=[f'{comp}', 'outputGridType'], value=f'{interp_split[0]}_{interp_split[1]}.{interp_method}')
 
   # write rose configs
   print("Writing output files...")

--- a/fre/pp/configure_script_yaml.py
+++ b/fre/pp/configure_script_yaml.py
@@ -38,12 +38,11 @@ def yamlInfo(yamlfile,experiment,platform,target):
 ### Copy pp yaml into cylc-src directory, make rose-suite, then IF remap and regrid paths defined, write those in cylcsrc/app/...
 
   # Make sure cylc-src exists (it should if this is done after fre checkout) and cd into
-  directory = os.path.expanduser("~/cylc-src")
-  name = f"{e}__{p}__{t}"
   # Copy pp yaml into ~/cylc-src/name
-  shutil.copyfile(yml,directory+"/"+name+"/pp.yaml")  
-  # Go into cylc-src directory
-  os.chdir(directory+"/"+name)
+  cylc_dir = os.path.join(os.path.expanduser("~/cylc-src"), f"{e}__{p}__{t}")
+  shutil.copyfile(yml, os.path.join(cylc_dir, 'pp.yaml')  )
+  # verify the directory exists
+  os.chdir(cylc_dir)
 
 ### PARSE YAML
 ## Write the rose-suite-exp configuration

--- a/fre/pp/configure_script_yaml.py
+++ b/fre/pp/configure_script_yaml.py
@@ -61,20 +61,7 @@ def yamlInfo(yamlfile,experiment,platform,target):
     y=yaml.safe_load(f)
     valyml = validateYaml(y)
 
-###################
-### Copy pp yaml into cylc-src directory, make rose-suite, then IF remap and regrid paths defined, write those in cylcsrc/app/...
-
-  # Make sure cylc-src exists (it should if this is done after fre checkout) and cd into
-  # Copy pp yaml into ~/cylc-src/name
-  cylc_dir = os.path.join(os.path.expanduser("~/cylc-src"), f"{e}__{p}__{t}")
-  shutil.copyfile(yml, os.path.join(cylc_dir, 'pp.yaml')  )
-  # verify the directory exists
-  os.chdir(cylc_dir)
-
-### PARSE YAML
-## Write the rose-suite-exp configuration
   for key,value in y.items():
-
     if key == "rose-suite":
       for suiteconfiginfo,dict in value.items():
         for configkey,configvalue in dict.items():
@@ -112,16 +99,23 @@ def yamlInfo(yamlfile,experiment,platform,target):
           rose_regrid.set(keys=[f'{comp}', 'outputGridLat'], value=f'{interp_split[0]}')
           rose_regrid.set(keys=[f'{comp}', 'outputGridType'], value=f'{interp_split[0]}_{interp_split[1]}.{interp_method}')
 
-  # write rose configs
+  # write output files
   print("Writing output files...")
-  os.chdir(cylc_dir)
+  cylc_dir = os.path.join(os.path.expanduser("~/cylc-src"), f"{e}__{p}__{t}")
+
+  outfile = os.path.join(cylc_dir, 'pp.yaml')
+  shutil.copyfile(yml, outfile)
+  print("  " + outfile)
+
   dumper = metomi.rose.config.ConfigDumper()
   outfile = os.path.join(cylc_dir, "rose-suite.conf")
   dumper(rose_suite, outfile)
   print("  " + outfile)
+
   outfile = os.path.join(cylc_dir, "app", "regrid-xy", "rose-app.conf")
   dumper(rose_regrid, outfile)
   print("  " + outfile)
+
   outfile = os.path.join(cylc_dir, "app", "remap-pp-components", "rose-app.conf")
   dumper(rose_remap, outfile)
   print("  " + outfile)

--- a/fre/pp/ppyaml_test/pp.yaml
+++ b/fre/pp/ppyaml_test/pp.yaml
@@ -1,225 +1,79 @@
-## User defined edits
-# Paths for where the rose-suite and rose-app configurations are in checked out pp repo
-configuration_paths: 
-  rose-suite: "."  
-  rose-remap: "app/remap-pp-components/rose-app.conf" 
-  rose-regrid: "app/regrid-xy/rose-app.conf" 
-
-ana_amip_len: &ANA_AMIP_LEN "10yr"
-pp_amip_chunk: &PP_AMIP_CHUNK96 "1yr"
-ana_amip_start: &ANA_AMIP_START "1980"
-ana_amip_stop: &ANA_AMIP_STOP "1988"
-defaultxyInterp: &defaultxyInterp "180,288"
+# "FRE properties" :)
+define1: &xyInterp "180,288"
 
 rose-suite:
   settings:
     history_segment: "P1Y"
-    pp_start: *ANA_AMIP_START
-    pp_stop: *ANA_AMIP_STOP
-    len: *ANA_AMIP_LEN
-    site: "ppan"
-    fre_analyis_home: #"/home/fms/local/opt/fre-analysis/test"
-    pp_chunk_a: "P5Y"
-    pp_chunk_b: "P10Y"
-    pp_default_xyinterp: *defaultxyInterp
+    pp_start: "1980"
+    pp_stop: "1988"
+    pp_chunk_a: "P1Y"
+    pp_chunk_b: "P5Y"
     pp_components: "atmos atmos_scalar land"
     pp_grid_spec: "/archive/oar.gfdl.am5/model_gen5/inputs/c96_grid/c96_OM4_025_grid_No_mg_drag_v20160808.tar"
 
   switches:
-    clean_work: True
-    do_mdtf: False
-    do_statics: False
+    do_statics: True
     do_timeavgs: True
+    clean_work: True
     do_refinediag: False
     do_atmos_plevel_masking: True
     do_preanalysis: False
     do_analysis: False
-    do_analysis_only: False
 
   directories:
     history_dir: "/archive/c2b/am5/2022.01/c96L65_am5f1a0r0_amip/gfdl.ncrc5-intel22-classic-prod-openmp/history"
     pp_dir: "/archive/$USER/canopy/am5/c96L65_amip/pp"
     ptmp_dir: "/xtmp/$USER/ptmp"
-    refinediag_scripts: "$(includeDir)/refineDiag/refineDiag_atmos_cmip6.csh"
-    preanalysis_script: "$(includeDir)/refineDiag/refineDiag_data_stager_globalAve.csh"
-    history_refined: "/archive/$USER/canopy/am5/c96L65_amip/history_refineDiag"
-    analysis: #"/nbhome/$USER/canopy/analysis/am5_c96L65_amip"
+    analysis: "/nbhome/$USER/canopy/analysis/am5_c96L65_amip"
 
-#regrid-xy and remap-pp-components information
-#regrid-remap-info:
 components:
   - type: "atmos_cmip"
-    start: *ANA_AMIP_START
-    sources: "atmos_month_cmip"
+    sources: "atmos_month_cmip atmos_8xdaily_cmip atmos_daily_cmip"
     sourceGrid: "cubedsphere"
-    xyInterp: *defaultxyInterp  
+    xyInterp: *xyInterp  
     interpMethod: "conserve_order2"
-    timeSeries:
-      - freq: "3hr"
-        source: "atmos_8xdaily_cmip"
-        chunkLength: *PP_AMIP_CHUNK96
-      - freq: "daily"
-        source: "atmos_daily_cmip"
-        chunkLength: *PP_AMIP_CHUNK96
-        variables: "huss tasmin tasmax tas pr psl sfcWind hurs uas vas zg500 ua10 ua850 va850 ua200"
-      - freq: "monthly"
-        source: "atmos_month_refined"
-        chunkLength: *PP_AMIP_CHUNK96
-      - freq: "monthly"
-        chunkLength: *PP_AMIP_CHUNK96
-    timeAverage:
-      - source: "monthly"
-        interval: *PP_AMIP_CHUNK96
-      - source: "monthly"
-        interval: *ANA_AMIP_LEN
-      - source: "annual"
-        interval: *PP_AMIP_CHUNK96
-        calcInterval: *PP_AMIP_CHUNK96
+    inputRealm: 'atmos'
   - type: "atmos"
-    zInterp: "era40"
-    start: *ANA_AMIP_START
     sources: "atmos_month"
     sourceGrid: "cubedsphere"
-    xyInterp: *defaultxyInterp
+    xyInterp: *xyInterp
     interpMethod: "conserve_order2"
-    cmip: "off"
-    timeSeries:
-      - freq: "6hr"
-        source: "atmos_4xdaily"
-        chunkLength: *PP_AMIP_CHUNK96
-      - freq: "monthly"
-        chunkLength: *PP_AMIP_CHUNK96
-    timeAverage:
-      - source: "monthly"
-        interval: *PP_AMIP_CHUNK96
-      - source: "monthly"
-        interval: *ANA_AMIP_LEN
-      - source: "annual"
-        interval: *PP_AMIP_CHUNK96
-        calcInterval: *PP_AMIP_CHUNK96
-      - source: "annual"
-        interval: *ANA_AMIP_LEN
-  - type: "atmos_level_cmip"
-    start: *ANA_AMIP_START
+    inputRealm: 'atmos'
+  - type: "atmos_level"
     sources: "atmos_level_cmip"
     sourceGrid: "cubedsphere"
-    xyInterp: *defaultxyInterp
+    xyInterp: *xyInterp
     interpMethod: "conserve_order2"
-    cmip: "on"
-    timeSeries:
-      - freq: "monthly"
-        chunkLength: *PP_AMIP_CHUNK96
-  - type: "atmos_level"
-    start: *ANA_AMIP_START
-    sources: "atmos_month"
-    sourceGrid: "cubedsphere"
-    xyInterp: *defaultxyInterp
-    interpMethod: "conserve_order2"
-    cmip: "off"
-    timeSeries:
-      - freq: "monthly"
-        chunkLength: *PP_AMIP_CHUNK96
-      - freq: "annual"
-        chunkLength: *PP_AMIP_CHUNK96
-    timeAverage:
-      - source: "monthly"
-        interval: *PP_AMIP_CHUNK96
-      - source: "monthly"
-        interval: *ANA_AMIP_LEN
+    inputRealm: 'atmos'
   - type: "atmos_month_aer"
-    start: *ANA_AMIP_START
     sources: "atmos_month_aer"
     sourceGrid: "cubedsphere"
-    xyInterp: *defaultxyInterp
+    xyInterp: *xyInterp
     interpMethod: "conserve_order1"
-    cmip: "on"
-    timeAverage:
-      - source: "monthly"
-        interval: *PP_AMIP_CHUNK96
-      - source:  "monthly"
-        interval: *ANA_AMIP_LEN
-    timeSeries:
-      - freq: "monthly"
-        chunkLength: *PP_AMIP_CHUNK96
+    inputRealm: 'atmos'
   - type: "atmos_diurnal"
-    start: *ANA_AMIP_START
     sources: "atmos_diurnal"
-    sourceGrid: "cubed-sphere"
-    xyInterp: *defaultxyInterp
-    interpMethod: conserve_order2
-    timeSeries:
-      - freq: "monthly"
-        chunklength: *PP_AMIP_CHUNK96
-  - type: "atmos_scalar"
-    start: *ANA_AMIP_START
-    sources: "atmos_scalar"
-    cmip: "on"
-    timeSeries:
-      - freq: "monthly"
-        chunkLength: *PP_AMIP_CHUNK96
-      - freq: "monthly"
-        source: "atmos_global_cmip"
-        chunkLength: *PP_AMIP_CHUNK96
-  - type: "tracer_level"
-    start: *ANA_AMIP_START
-    sources: "atmos_tracer"
     sourceGrid: "cubedsphere"
-    xyInterp: *defaultxyInterp
-    interpMethod: "conserve_order1"
-    cmip: "on"
-    timeSeries:
-      - freq: "monthly"
-        chunkLength: *PP_AMIP_CHUNK96
-      - freq: "annual"
-        chunkLength: *PP_AMIP_CHUNK96
-    timeAverage:
-      - source: "monthly"
-        interval: *PP_AMIP_CHUNK96
-      - source: "monthly"
-        interval: *ANA_AMIP_LEN
+    xyInterp: *xyInterp
+    interpMethod: "conserve_order2"
+    inputRealm: 'atmos'
+  - type: "atmos_scalar"
+    sources: "atmos_scalar"
   - type: "aerosol_cmip"
-    start: *ANA_AMIP_START
-    xyInterp: *defaultxyInterp
+    xyInterp: *xyInterp
     sources: "aerosol_month_cmip"
     sourceGrid: "cubedsphere"
     interpMethod: "conserve_order1"
-    cmip: "on"
-    timeSeries:
-      - freq: "monthly"
-        chunkLength: *PP_AMIP_CHUNK96
-      - freq: "monthly"
-        chunkLength: *PP_AMIP_CHUNK96
-        source: "aerosol_month_refined"
+    inputRealm: 'atmos'
   - type: "land"
-    start: *ANA_AMIP_START
     sources: "land_month"
     sourceGrid: "cubedsphere"
-    xyInterp: *defaultxyInterp
+    xyInterp: *xyInterp
     interpMethod: "conserve_order1"
-    cmip: "off"
-    timeSeries:
-      - freq: "monthly"
-        chunkLength: *PP_AMIP_CHUNK96
-    timeAverage:
-      - source: "monthly"
-        interval: *PP_AMIP_CHUNK96
-      - source: "monthly"
-        interval: *ANA_AMIP_LEN
+    inputRealm: 'land'
   - type: "land_cmip"
-    start: *ANA_AMIP_START
     sources: "land_month_cmip"
     sourceGrid: "cubedsphere"
-    xyInterp: *defaultxyInterp
+    xyInterp: *xyInterp
     interpMethod: "conserve_order1"
-    cmip: "off"
-    timeSeries:
-      - freq: "monthly"
-        chunkLength: *PP_AMIP_CHUNK96
-
-tmpdir:
-  tmpdirpath:
-
-install-exp-script:
-    - path: 
-    - install-option:
-        install: 
+    inputRealm: 'land'

--- a/fre/pp/ppyaml_test/pp.yaml
+++ b/fre/pp/ppyaml_test/pp.yaml
@@ -77,3 +77,11 @@ components:
     xyInterp: *xyInterp
     interpMethod: "conserve_order1"
     inputRealm: 'land'
+
+tmpdir:
+  tmpdirpath:
+￼
+install-exp-script:
+    - path:
+    - install-option:
+        install:

--- a/fre/pp/ppyaml_test/pp.yaml
+++ b/fre/pp/ppyaml_test/pp.yaml
@@ -80,8 +80,8 @@ components:
 
 tmpdir:
   tmpdirpath:
-￼
+
 install-exp-script:
-    - path:
-    - install-option:
-        install:
+  - path:
+  - install-option:
+    install:

--- a/fre/pp/ppyaml_test/pp.yaml
+++ b/fre/pp/ppyaml_test/pp.yaml
@@ -22,7 +22,7 @@ rose-suite:
 
   directories:
     history_dir: "/archive/c2b/am5/2022.01/c96L65_am5f1a0r0_amip/gfdl.ncrc5-intel22-classic-prod-openmp/history"
-    pp_dir: "/archive/$USER/canopy/am5/c96L65_amip/pp"
+    pp_dir: "/archive/$USER/canopy/am5/c96L65_amip/gfdl.ncrc5-deploy-prod-openmp/pp"
     ptmp_dir: "/xtmp/$USER/ptmp"
     analysis: "/nbhome/$USER/canopy/analysis/am5_c96L65_amip"
 

--- a/fre/pp/schema.json
+++ b/fre/pp/schema.json
@@ -3,20 +3,6 @@
   "title": "Schema for PP Yaml",
   "type": "object",
   "properties": {
-    "configuration_paths": { 
-      "type": "object",
-      "properties": {
-        "rose-suite": {"type": "string"},
-        "rose-remap": {"type": ["string","null"]},
-        "rose-regrid": {"type": ["string","null"]}
-      }
-    },
-    "ana_amip_len": {"type": "string"},
-    "pp_amip_chunk": {"type": "string"},
-    "ana_amip_start": {"type": "string"},
-    "ana_amip_stop": {"type": "string"},
-    "defaultxyInterp": {"type": "string"},
-
     "rose-suite": {
       "type": "object",
       "properties": {
@@ -26,7 +12,6 @@
             "history_segment": {"type":"string"},
             "pp_start": {"type":"string"},
             "pp_stop": {"type":"string"},
-            "len": {"type":"string"},
             "site": {"type":"string"},
             "fre_analysis_home": {"type":["string","null"]},
             "pp_chunk_a": {"type":"string"},
@@ -74,30 +59,11 @@
       "type":"object",
       "properties": {
         "type": {"type":"string"},
-        "start": {"type":"string"},
         "sources": {"type":"string"},
         "sourceGrid": {"type":"string"},
         "xyInterp": {"type":"string"},
-        "zInterp": {"type":"string"},
         "interpMethod": {"type":"string"},
-        "cmip": {"type":"string"},
-        "timeSeries": {
-          "type": "array",
-          "properties": {
-            "freq": {"type":"string"},
-            "source": {"type":"string"},
-            "chunkLength": {"type":"string"},
-            "variables": {"type":"string"}
-          }
-        },
-        "timeAverage": {
-          "type": "array",
-          "properties": {
-            "source": {"type":"string"},
-            "interval": {"type":"string"},
-            "calcInterval": {"type":"string"}
-          }
-        }
+        "inputRealm": {"type":"string"}
       }
     },
     "tmpdir": {


### PR DESCRIPTION
Minor cleanup:
* use metomi.rose for writing rose config files
* retrieve pathnames from command line arguments instead of pp.yaml

Also simplify some of the pp.yaml component definitions, by removing timeseries and timeaverage tags that are not absolutely needed in canopy.