### PR TITLE
Update meta.yaml

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - pylint
     - jsonschema
     - noaa-gfdl::intakebuilder
-    - conda-forge::cylc-flow
+    - conda-forge::cylc-flow>=8.2.0
     - conda-forge::cylc-rose
     - conda-forge::metomi-rose
     - conda-forge::cmor


### PR DESCRIPTION
`conda-forge::cylc-flow`


changed to 


`conda-forge::cylc-flow>=8.2.0`

making this PR to launch to CI/CD conda build process