### PR TITLE
Remove extra `write` for `c[additional instructions]`

### DIFF
--- a/fre/make/gfdlfremake/checkout.py
+++ b/fre/make/gfdlfremake/checkout.py
@@ -76,8 +76,6 @@ class checkout():
                writeRepo(self.checkoutScript,repo,c['component'],self.src,branch,c['additionalInstructions'],True,jobs,pc)
      else:
           writeRepo(self.checkoutScript,c['repo'],c['component'],self.src,c['branch'],c['additionalInstructions'],False,jobs,pc)
-## Add additional instructions
-     self.checkoutScript.write(c['additionalInstructions'])
 ## \brief If pc is defined: Loops through dictionary of pids, waits for each pid individually, writes exit code in `check` list; allows checkoutscript to exit if exit code is not 0; closes the checkout script when writing is done
 ## \param self The checkout script object
  def finish (self,pc):


### PR DESCRIPTION
## Describe your changes
Remove `self.checkoutScript.write(c['additionalInstructions'])` because this step was done previously. This line was redundant and was causing `additionalInstructions` to be written one more time than needed in the checkout script that is created. 

## Issue ticket number and link (if applicable)
N/A
## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback