### PR TITLE
Locate the experiment pp.yamls relative to the main yaml dir

### DIFF
--- a/fre/pp/configure_script_yaml.py
+++ b/fre/pp/configure_script_yaml.py
@@ -60,6 +60,9 @@ def consolidate_yamls(mainyaml,experiment, platform,target):
     """
     Combine main yaml and experiment yaml into combined yamls
     """
+    # Retrieve the directory containing the main yaml, to use
+    # as an offset for the child yamls
+    mainyaml_dir = os.path.dirname(mainyaml)
     # Path to new combined
     combined=Path("combined.yaml")
     # Create and write to combined yaml
@@ -101,7 +104,8 @@ def consolidate_yamls(mainyaml,experiment, platform,target):
         with open(combined,"a") as f1:
             for i in expyaml:
                 expname_list.append(i.split(".")[1])
-                with open(i,'r') as f2:
+                expyaml_path = os.path.join(mainyaml_dir, i)
+                with open(expyaml_path,'r') as f2:
                     f1.write(f"\n### {i.upper()} settings ###\n")
                     #copy expyaml into combined
                     shutil.copyfileobj(f2,f1)


### PR DESCRIPTION
## Describe your changes
`fre pp configure-yaml` was unable to locate the child experiment pp.yaml. An update to prepend the directory containing the main yaml resolves the problem.

## Issue ticket number and link (if applicable)
#99 


## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
