### PR TITLE
make `pylint` output more easily accessible in CI/CD

### DIFF
--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -35,4 +35,16 @@ jobs:
         python --version
         $CONDA/envs/fre-cli/bin/python --version
         # run pytest
-        $CONDA/envs/fre-cli/bin/pytest
+        #$CONDA/envs/fre-cli/bin/pytest
+        pytest --config-file=fre/pytest.ini --cov-config=fre/coveragerc --cov=fre fre/
+
+    - name: Run pylint in fre-cli environment
+      run: |
+        # try to make sure the right things are in GITHUB_PATH
+        echo $CONDA/envs/fre-cli/bin >> $GITHUB_PATH
+        which python
+        python --version
+        $CONDA/envs/fre-cli/bin/python --version
+        # run pytest
+        #$CONDA/envs/fre-cli/bin/pylint
+        pylint fre/ || echo "pylint returned non-zero exit code. preventing workflow from dying with this echo."

--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -35,7 +35,6 @@ jobs:
         python --version
         $CONDA/envs/fre-cli/bin/python --version
         # run pytest
-        #$CONDA/envs/fre-cli/bin/pytest
         pytest --config-file=fre/pytest.ini --cov-config=fre/coveragerc --cov=fre fre/
 
     - name: Run pylint in fre-cli environment
@@ -46,5 +45,4 @@ jobs:
         python --version
         $CONDA/envs/fre-cli/bin/python --version
         # run pytest
-        #$CONDA/envs/fre-cli/bin/pylint
         pylint fre/ || echo "pylint returned non-zero exit code. preventing workflow from dying with this echo."

--- a/fre/fre.py
+++ b/fre/fre.py
@@ -34,6 +34,7 @@ from .lazy_group import LazyGroup
 )
 
 def fre():
+    ''' entry point function to subgroup functions '''
     pass
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Describe your changes
this runs `pylint` as part of the `conda env create` check, in a separate workflow from `conda build` routines. it lets the `pylint` feedback be accessed with a single click- see checks on this PR!

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
~~- [ ] I tried to comment my code~~
~~- [ ] I wrote a new test, if applicable~~
~~- [ ] I wrote new instructions/documentation, if applicable~~
~~- [ ] I ran pytest and inspected it's output~~
- [x] I ran pylint and attempted to implement some of it's feedback
