### PR TITLE
Update test_fre_cli.py

### DIFF
--- a/fre/tests/test_fre_cli.py
+++ b/fre/tests/test_fre_cli.py
@@ -58,12 +58,8 @@ def test_cli_fre_catalog():
     result = runner.invoke(fre.fre, args=["catalog"])
     assert result.exit_code == 0
 
-def test_cli_fre_catalog_builder():
-    result = runner.invoke(fre.fre, args=["catalog", "builder"])
-    assert result.exit_code == 0
-
-def test_cli_fre_catalog_builder():
-    result = runner.invoke(fre.fre, args=["catalog", "builder", "/archive/FIRST.LAST/fre/FMS2023.04_om5_20240410/ESM4.2JpiC_om5b04r1/gfdl.ncrc5-intel23-prod-openmp/pp"])
+def test_cli_fre_catalog_builder_help():
+    result = runner.invoke(fre.fre, args=["catalog", "builder", "--help"])
     assert result.exit_code == 0
 
 def test_cli_fre_catalog_help():

--- a/fre/tests/test_fre_cli.py
+++ b/fre/tests/test_fre_cli.py
@@ -58,6 +58,14 @@ def test_cli_fre_catalog():
     result = runner.invoke(fre.fre, args=["catalog"])
     assert result.exit_code == 0
 
+def test_cli_fre_catalog_builder():
+    result = runner.invoke(fre.fre, args=["catalog", "builder"])
+    assert result.exit_code == 0
+
+def test_cli_fre_catalog_builder():
+    result = runner.invoke(fre.fre, args=["catalog", "builder", "/archive/FIRST.LAST/fre/FMS2023.04_om5_20240410/ESM4.2JpiC_om5b04r1/gfdl.ncrc5-intel23-prod-openmp/pp"])
+    assert result.exit_code == 0
+
 def test_cli_fre_catalog_help():
     result = runner.invoke(fre.fre, args=['--help', "catalog"])
     assert result.exit_code == 0


### PR DESCRIPTION
`catalogbuilder`'s API changed, causing `fre catalog builder` to throw an error. the tests should catch this but do not currently.

updating with a test that will fail, which should show itself in the pipeline.
