### PR TITLE
tweak pipeline

### DIFF
--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -29,38 +29,21 @@ jobs:
           # use *conda environment's pip* to install fre-cli
           # called w/ full path to conda's python for explicitness
           # called as a module (-m pip) for explicitness
-          $CONDA/envs/fre-cli/bin/python -m pip install --prefix $CONDA/envs/fre-cli .
-      
-      - name: Run pytest in fre-cli environment
-        run: |
-          # add conda env's executables to github's PATH equiv.
-          # does this need to be done twice?
-          echo $CONDA/envs/fre-cli/bin >> $GITHUB_PATH
-
-          # are we talking to the right python?
-          which python
-          python --version
-          $CONDA/envs/fre-cli/bin/python --version
-          
-          # run pytest, not explicitly from the conda env?
-          which pytest
-          pytest --config-file=fre/pytest.ini --cov-config=fre/coveragerc --cov=fre fre/
-      
-      - name: Run pylint in fre-cli environment
-        run: |
-          # add conda env's executables to github's PATH equiv.
-          # does this need to be done a third time?
-          echo $CONDA/envs/fre-cli/bin >> $GITHUB_PATH
+          $CONDA/envs/fre-cli/bin/python -m pip install --prefix $CONDA/envs/fre-cli .      
 
       - name: Run pytest in fre-cli environment
         run: |
           # try to make sure the right things are in GITHUB_PATH
           echo $CONDA/envs/fre-cli/bin >> $GITHUB_PATH
+          
+          # are we talking to the right python?
           which python
           python --version
           $CONDA/envs/fre-cli/bin/python --version
+          
           # run pytest
           pytest --junit-xml=pytest_results.xml --config-file=fre/pytest.ini --cov-config=fre/coveragerc --cov-report=xml --cov=fre fre/
+          
           # install genbadge to generate coverage badge based on xml
           pip install genbadge
           genbadge coverage -v -i coverage.xml -o docs/cov_badge.svg
@@ -70,11 +53,14 @@ jobs:
         run: |
           # try to make sure the right things are in GITHUB_PATH
           echo $CONDA/envs/fre-cli/bin >> $GITHUB_PATH
+
+          # are we talking to the right python?
           which python
           python --version
           $CONDA/envs/fre-cli/bin/python --version
+          
           # run pylint
-          pylint fre/ || echo "pylint returned non-zero exit code. preventing workflow from dying with this echo."
+          pylint --ignored-modules netCDF4 fre/ || echo "pylint returned non-zero exit code. preventing workflow from dying with this echo."
       
       - name: Install Sphinx and Build Documentation
         run: |


### PR DESCRIPTION
removes redundant tasks that snuck into the workflow file, adds back in a flag to ignore `pylint` warnings regarding `netCDF4`- that orginates from that module's code and not `fre-cli`



## Checklist before requesting a review

- [ ] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
