### PR TITLE
Update "fre catalog builder" test after upstream CatalogBuilder change

### DIFF
--- a/fre/tests/test_fre_catalog_cli.py
+++ b/fre/tests/test_fre_catalog_cli.py
@@ -24,12 +24,7 @@ def test_cli_fre_catalog_opt_dne():
 def test_cli_fre_catalog_builder():
     ''' fre catalog builder '''
     result = runner.invoke(fre.fre, args=["catalog", "builder"])
-    assert all( [
-                  result.exit_code == 1,
-                  'No paths given, using yaml configuration'
-                    in result.stdout.split('\n')
-                ]
-              )
+    assert result.exit_code == 1
 
 def test_cli_fre_catalog_builder_help():
     ''' fre catalog builder --help '''

--- a/fre/tests/test_fre_catalog_cli.py
+++ b/fre/tests/test_fre_catalog_cli.py
@@ -24,7 +24,12 @@ def test_cli_fre_catalog_opt_dne():
 def test_cli_fre_catalog_builder():
     ''' fre catalog builder '''
     result = runner.invoke(fre.fre, args=["catalog", "builder"])
-    assert result.exit_code == 1
+    assert all( [
+                  result.exit_code == 1,
+                  'Missing: input_path or output_path. Pass it in the config yaml or as command-line option'
+                    in result.stdout.split('\n')
+                ]
+              )
 
 def test_cli_fre_catalog_builder_help():
     ''' fre catalog builder --help '''


### PR DESCRIPTION
Previously, the test verified the exit code and message for

(fre-cli) c2b:~/git/fre-cli%>fre catalog builder
No paths given, using yaml configuration

(fre-cli) c2b:~/git/fre-cli%>echo $status
1

Recently, the message was updated to be:

(fre-cli) c2b:~/git/fre-cli%>fre catalog builder 
Missing: input_path or output_path. Pass it in the config yaml or as command-line option

(fre-cli) c2b:~/git/fre-cli%>echo $status 
1

So let's continue to check for the exit code and not require an exact error message.

## Describe your changes

## Issue ticket number and link (if applicable)

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
