### PR TITLE
fix absolute paths for yaml combiner

### DIFF
--- a/fre/yamltools/combine_yamls.py
+++ b/fre/yamltools/combine_yamls.py
@@ -38,7 +38,7 @@ def get_compile_paths(mainyaml_dir,comb):
 
     # set platform yaml filepath
     if comb_model["build"]["platformYaml"] is not None:
-        if Path(comb_model["build"]["platformYaml"]).exists():
+        if Path(os.path.join(mainyaml_dir,comb_model["build"]["platformYaml"])).exists():
             py=comb_model["build"]["platformYaml"]
             py_path=Path(os.path.join(mainyaml_dir,py))
         else:
@@ -49,7 +49,7 @@ def get_compile_paths(mainyaml_dir,comb):
 
     # set compile yaml filepath
     if comb_model["build"]["compileYaml"] is not None:
-        if Path(comb_model["build"]["compileYaml"]).exists():
+        if Path(os.path.join(mainyaml_dir,comb_model["build"]["compileYaml"])).exists():
             cy=comb_model["build"]["compileYaml"]
             cy_path=Path(os.path.join(mainyaml_dir,cy))
         else:
@@ -119,17 +119,18 @@ class init_compile_yaml():
     """
     self.yml = yamlfile
     self.name = yamlfile.split(".")[0]
+    self.namenopath = self.name.split("/")[-1].split(".")[0]
     self.platform = platform
     self.target = target
 
-    # Regsiter tag handler
+    # Register tag handler
     yaml.add_constructor('!join', join_constructor)
 
     # Path to the main model yaml
     self.mainyaml_dir = os.path.dirname(self.yml)
 
     # Name of the combined yaml
-    self.combined=f"combined-{self.name}.yaml"
+    self.combined=f"{self.mainyaml_dir}/combined-{self.namenopath}.yaml"
 
     print("Combining yaml files: ")
 

--- a/fre/yamltools/combine_yamls.py
+++ b/fre/yamltools/combine_yamls.py
@@ -130,7 +130,7 @@ class init_compile_yaml():
     self.mainyaml_dir = os.path.dirname(self.yml)
 
     # Name of the combined yaml
-    self.combined=f"{self.mainyaml_dir}/combined-{self.namenopath}.yaml"
+    self.combined= f"combined-{self.namenopath}.yaml" if len(self.mainyaml_dir) == 0 else  f"{self.mainyaml_dir}/combined-{self.namenopath}.yaml"
 
     print("Combining yaml files: ")
 


### PR DESCRIPTION
## Describe your changes
Just a small fix for the combiner failing when given an absolute path for the yaml input file.

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [x] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [x] I ran pylint and attempted to implement some of it's feedback
