### PR TITLE
Add click bindings for 'fre catalog merge'

### DIFF
--- a/fre/catalog/frecatalog.py
+++ b/fre/catalog/frecatalog.py
@@ -6,6 +6,7 @@ import click
 #import catalogbuilder
 from catalogbuilder.scripts import gen_intake_gfdl
 from catalogbuilder.scripts import test_catalog
+from catalogbuilder.scripts import combine_cats
 
 
 @click.group(help=click.style(" - access fre catalog subcommands", fg=(64,94,213)))
@@ -46,6 +47,16 @@ def validate(context, json_path, json_template_path, test_failure):
     # pylint: disable=unused-argument
     """ - Validate a catalog against catalog schema """
     context.forward(test_catalog.main)
+
+@catalog_cli.command()
+@click.option('--input', required = True, multiple = True,
+              help = 'Catalog json files to be merged, space-separated')
+@click.option('--output', required = True, nargs = 1,
+              help = 'Merged catalog')
+@click.pass_context
+def merge(context, input, output):
+    """ - Merge two or more more catalogs into one """
+    context.invoke(combine_cats.combine_cats, inputfiles=input, output_path=output)
 
 if __name__ == "__main__":
     catalog_cli()

--- a/fre/tests/test_fre_catalog_cli.py
+++ b/fre/tests/test_fre_catalog_cli.py
@@ -36,3 +36,15 @@ def test_cli_fre_catalog_builder_help():
     ''' fre catalog builder --help '''
     result = runner.invoke(fre.fre, args=["catalog", "builder", "--help"])
     assert result.exit_code == 0
+
+def test_cli_fre_catalog_merge():
+    result = runner.invoke(fre.fre, args=["catalog", "merge"])
+    expected_stdout = "Error: Missing option '--input'."
+    assert all( [
+        result.exit_code == 2,
+        expected_stdout in result.stdout.split('\n')
+    ] )
+
+def test_cli_fre_catalog_merge_help():
+    result = runner.invoke(fre.fre, args=["catalog", "merge", "--help"])
+    assert result.exit_code == 0


### PR DESCRIPTION
## Describe your changes
Added fre-cli interface (`fre catalog merge`) to catalog combining tool in CatalogBuilder (https://github.com/NOAA-GFDL/CatalogBuilder/blob/main/catalogbuilder/scripts/combine_cats.py)

```
>fre catalog merge --help   

Usage: fre catalog merge [OPTIONS]

  - Merge two or more more catalogs into one

Options:
  --input TEXT   Catalog json files to be merged, space-separated  [required]
  --output TEXT  Merged catalog  [required]
  --help         Show this message and exit.
```

```
>fre catalog merge --input ~/catalog/catalog1.json --input ~/catalog/catalog2.json --output mycat

/home/c2b/catalog/catalog1.csv
/home/c2b/catalog/catalog2.csv
INFO: Schema differs
{'catalog_file': '/home/Chris.Blanton/catalog/catalog2.csv'}
We can combine since the catalog_file is the only difference
Combined catalog specification-  mycat
Combined csv/catalog-  mycat.csv
```

## Issue ticket number and link (if applicable)
https://github.com/NOAA-GFDL/CatalogBuilder/discussions/50

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
