### PR TITLE
 #212 Make compile and checkout scripts executable

### DIFF
--- a/fre/make/gfdlfremake/buildBaremetal.py
+++ b/fre/make/gfdlfremake/buildBaremetal.py
@@ -110,6 +110,9 @@ class buildBaremetal():
         self.f.write(self.make+"\n")
         self.f.close()
 
+        # Make compile script executable
+        os.chmod(self.bld+"/compile.sh", 0o744)
+
 ## TODO run as a batch job on the login cluster
     def run(self):
         """
@@ -118,7 +121,6 @@ class buildBaremetal():
             - self : The dockerfile object
         """
 ###### TODO make the Makefile
-        os.chmod(self.bld+"/compile.sh", 0o744)
         command = [self.bld+"/compile.sh","|","tee",self.bld+"/log.compile"]
         try:
             subprocess.run(args=command, check=True)

--- a/fre/make/gfdlfremake/checkout.py
+++ b/fre/make/gfdlfremake/checkout.py
@@ -108,6 +108,9 @@ class checkout():
         else:
             self.checkoutScript.close()
 
+        # Make checkout script executable
+        os.chmod(self.src+"/"+self.fname, 0o744)
+
 ## TODO: batch script building
     def run (self):
         """
@@ -115,7 +118,6 @@ class checkout():
         Param:
             - self The checkout script object
         """
-        os.chmod(self.src+"/"+self.fname, 0o744)
         try:
             subprocess.run(args=[self.src+"/"+self.fname], check=True)
         except:


### PR DESCRIPTION
- make scripts executable after creating
- moved `chmod` lines earlier in scripts

## Describe your changes

## Issue ticket number and link (if applicable)

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
