### PR TITLE
 Fix making checkout script executable before running

### DIFF
--- a/fre/make/createCheckout.py
+++ b/fre/make/createCheckout.py
@@ -75,7 +75,9 @@ def checkout_create(yamlfile,platform,target,no_parallel_checkout,jobs,execute,v
                    freCheckout = checkout.checkout("checkout.sh",srcDir)
                    freCheckout.writeCheckout(modelYaml.compile.getCompileYaml(),jobs,pc)
                    freCheckout.finish(pc)
-                   click.echo("\nCheckout script created in "+ srcDir + "/checkout.sh \n")
+                   # Make checkout script executable
+                   os.chmod(srcDir+"/checkout.sh", 0o744)
+                   print("\nCheckout script created in "+ srcDir + "/checkout.sh \n")
 
                    # Run the checkout script
                    if run == True:
@@ -85,7 +87,6 @@ def checkout_create(yamlfile,platform,target,no_parallel_checkout,jobs,execute,v
               else:
                    print("\nCheckout script PREVIOUSLY created in "+ srcDir + "/checkout.sh \n")
                    if run == True:
-                        os.chmod(srcDir+"/checkout.sh", 0o744)
                         try:
                              subprocess.run(args=[srcDir+"/checkout.sh"], check=True)
                         except:
@@ -102,7 +103,7 @@ def checkout_create(yamlfile,platform,target,no_parallel_checkout,jobs,execute,v
               freCheckout = checkout.checkoutForContainer("checkout.sh", srcDir, tmpDir)
               freCheckout.writeCheckout(modelYaml.compile.getCompileYaml(),jobs,pc)
               freCheckout.finish(pc)
-              click.echo("\nCheckout script created at " + tmpDir + "/checkout.sh" + "\n")
+              print("\nCheckout script created at " + tmpDir + "/checkout.sh" + "\n")
 
 
 if __name__ == "__main__":

--- a/fre/make/gfdlfremake/checkout.py
+++ b/fre/make/gfdlfremake/checkout.py
@@ -108,9 +108,6 @@ class checkout():
         else:
             self.checkoutScript.close()
 
-        # Make checkout script executable
-        os.chmod(self.src+"/"+self.fname, 0o744)
-
 ## TODO: batch script building
     def run (self):
         """


### PR DESCRIPTION
- want from users to be able to run checkout script themselves as well
- this is a fix: chmod needed to be moved to just be in `createCheckout`

## Describe your changes

## Issue ticket number and link (if applicable)

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
