### PR TITLE
update function names for run_fremake subcommand

### DIFF
--- a/fre/make/gfdlfremake/checkout.py
+++ b/fre/make/gfdlfremake/checkout.py
@@ -115,6 +115,7 @@ class checkout():
         Param:
             - self The checkout script object
         """
+        os.chmod(self.src+"/"+self.fname, 0o744)
         try:
             subprocess.run(args=[self.src+"/"+self.fname], check=True)
         except:

--- a/fre/make/gfdlfremake/checkout.py
+++ b/fre/make/gfdlfremake/checkout.py
@@ -111,11 +111,10 @@ class checkout():
 ## TODO: batch script building
     def run (self):
         """
-        Brief: Changes the permission on the checkout script and runs it
+        Brief: Runs the checkout script
         Param:
             - self The checkout script object
         """
-        os.chmod(self.src+"/"+self.fname, 0o744)
         try:
             subprocess.run(args=[self.src+"/"+self.fname], check=True)
         except:

--- a/fre/make/runFremake.py
+++ b/fre/make/runFremake.py
@@ -86,6 +86,7 @@ def fremake_run(yamlfile,platform,target,parallel,jobs,no_parallel_checkout,verb
                 freCheckout = checkout.checkout("checkout.sh",srcDir)
                 freCheckout.writeCheckout(modelYaml.compile.getCompileYaml(),jobs,pc)
                 freCheckout.finish(pc)
+                os.chmod(srcDir+"/checkout.sh", 0o744)
                 ## TODO: Options for running on login cluster?
                 freCheckout.run()
 

--- a/fre/make/runFremake.py
+++ b/fre/make/runFremake.py
@@ -15,7 +15,7 @@ from .gfdlfremake import (
     targetfre, varsfre, yamlfre, checkout,
     makefilefre, buildDocker, buildBaremetal )
 
-def _fremake_run(yamlfile,platform,target,parallel,jobs,no_parallel_checkout,verbose):
+def fremake_run(yamlfile,platform,target,parallel,jobs,no_parallel_checkout,verbose):
     ''' run fremake via click'''
     yml = yamlfile
     name = yamlfile.split(".")[0]
@@ -200,12 +200,12 @@ def _fremake_run(yamlfile,platform,target,parallel,jobs,no_parallel_checkout,ver
             pool.map(buildBaremetal.fremake_parallel,fremakeBuildList)
 
 @click.command()
-def fremake_run(yamlfile,platform,target,parallel,jobs,no_parallel_checkout,verbose):
+def _fremake_run(yamlfile,platform,target,parallel,jobs,no_parallel_checkout,verbose):
     '''
     Decorator for calling _fremake_run - allows the decorated version
     of the function to be separate from the undecorated version
     '''
-    return _fremake_run(yamlfile,platform,target,parallel,jobs,no_parallel_checkout,verbose)
+    return fremake_run(yamlfile,platform,target,parallel,jobs,no_parallel_checkout,verbose)
 
 if __name__ == "__main__":
     fremake_run()


### PR DESCRIPTION
## Describe your changes
Some changes needed to get the run-fremake subcommand working. Just switches around the names for `run_fremake` and adds a chmod.

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [x] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [x] I ran pylint and attempted to implement some of it's feedback
