### PR TITLE
basic doc updates 

### DIFF
--- a/.github/workflows/build_conda.yml
+++ b/.github/workflows/build_conda.yml
@@ -2,7 +2,8 @@ name: build_conda
 on:
   pull_request:
     branches:
-      - main
+	  - FOO
+#      - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_conda.yml
+++ b/.github/workflows/build_conda.yml
@@ -2,8 +2,7 @@ name: build_conda
 on:
   pull_request:
     branches:
-      - FOO
-#      - main
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_conda.yml
+++ b/.github/workflows/build_conda.yml
@@ -2,7 +2,7 @@ name: build_conda
 on:
   pull_request:
     branches:
-	  - FOO
+      - FOO
 #      - main
 jobs:
   build:

--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -32,36 +32,36 @@ jobs:
           ## called as a module (-m pip) for explicitness
           $CONDA/envs/fre-cli/bin/python -m pip install --prefix $CONDA/envs/fre-cli .
 
-      - name: Run pytest in fre-cli environment
-        run: |
-          # try to make sure the right things are in GITHUB_PATH
-          echo $CONDA/envs/fre-cli/bin >> $GITHUB_PATH
-          
-          # are we talking to the right python?
-          which python
-          python --version
-          $CONDA/envs/fre-cli/bin/python --version
-          
-          # run pytest
-          pytest --junit-xml=pytest_results.xml --config-file=fre/pytest.ini --cov-config=fre/coveragerc --cov-report=xml --cov=fre fre/
-          
-          # install genbadge to generate coverage badge based on xml
-          pip install genbadge
-          genbadge coverage -v -i coverage.xml -o docs/cov_badge.svg
-          genbadge tests -v -i pytest_results.xml -o docs/pytest_badge.svg
-        
-      - name: Run pylint in fre-cli environment
-        run: |
-          # try to make sure the right things are in GITHUB_PATH
-          echo $CONDA/envs/fre-cli/bin >> $GITHUB_PATH
-
-          # are we talking to the right python?
-          which python
-          python --version
-          $CONDA/envs/fre-cli/bin/python --version
-          
-          # run pylint, ignored modules avoid warnings arising from code internal to those modules 
-          pylint --max-args 6 -ry --ignored-modules netCDF4,cmor fre/ || echo "pylint returned non-zero exit code. preventing workflow from dying with this echo."
+#      - name: Run pytest in fre-cli environment
+#        run: |
+#          # try to make sure the right things are in GITHUB_PATH
+#          echo $CONDA/envs/fre-cli/bin >> $GITHUB_PATH
+#          
+#          # are we talking to the right python?
+#          which python
+#          python --version
+#          $CONDA/envs/fre-cli/bin/python --version
+#          
+#          # run pytest
+#          pytest --junit-xml=pytest_results.xml --config-file=fre/pytest.ini --cov-config=fre/coveragerc --cov-report=xml --cov=fre fre/
+#          
+#          # install genbadge to generate coverage badge based on xml
+#          pip install genbadge
+#          genbadge coverage -v -i coverage.xml -o docs/cov_badge.svg
+#          genbadge tests -v -i pytest_results.xml -o docs/pytest_badge.svg
+#        
+#      - name: Run pylint in fre-cli environment
+#        run: |
+#          # try to make sure the right things are in GITHUB_PATH
+#          echo $CONDA/envs/fre-cli/bin >> $GITHUB_PATH
+#
+#          # are we talking to the right python?
+#          which python
+#          python --version
+#          $CONDA/envs/fre-cli/bin/python --version
+#          
+#          # run pylint, ignored modules avoid warnings arising from code internal to those modules 
+#          pylint --max-args 6 -ry --ignored-modules netCDF4,cmor fre/ || echo "pylint returned non-zero exit code. preventing workflow from dying with this echo."
 
       - name: Install Sphinx and Build Documentation
         run: |
@@ -72,7 +72,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
+#        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -32,36 +32,36 @@ jobs:
           ## called as a module (-m pip) for explicitness
           $CONDA/envs/fre-cli/bin/python -m pip install --prefix $CONDA/envs/fre-cli .
 
-#      - name: Run pytest in fre-cli environment
-#        run: |
-#          # try to make sure the right things are in GITHUB_PATH
-#          echo $CONDA/envs/fre-cli/bin >> $GITHUB_PATH
-#          
-#          # are we talking to the right python?
-#          which python
-#          python --version
-#          $CONDA/envs/fre-cli/bin/python --version
-#          
-#          # run pytest
-#          pytest --junit-xml=pytest_results.xml --config-file=fre/pytest.ini --cov-config=fre/coveragerc --cov-report=xml --cov=fre fre/
-#          
-#          # install genbadge to generate coverage badge based on xml
-#          pip install genbadge
-#          genbadge coverage -v -i coverage.xml -o docs/cov_badge.svg
-#          genbadge tests -v -i pytest_results.xml -o docs/pytest_badge.svg
-#        
-#      - name: Run pylint in fre-cli environment
-#        run: |
-#          # try to make sure the right things are in GITHUB_PATH
-#          echo $CONDA/envs/fre-cli/bin >> $GITHUB_PATH
-#
-#          # are we talking to the right python?
-#          which python
-#          python --version
-#          $CONDA/envs/fre-cli/bin/python --version
-#          
-#          # run pylint, ignored modules avoid warnings arising from code internal to those modules 
-#          pylint --max-args 6 -ry --ignored-modules netCDF4,cmor fre/ || echo "pylint returned non-zero exit code. preventing workflow from dying with this echo."
+      - name: Run pytest in fre-cli environment
+        run: |
+          # try to make sure the right things are in GITHUB_PATH
+          echo $CONDA/envs/fre-cli/bin >> $GITHUB_PATH
+          
+          # are we talking to the right python?
+          which python
+          python --version
+          $CONDA/envs/fre-cli/bin/python --version
+          
+          # run pytest
+          pytest --junit-xml=pytest_results.xml --config-file=fre/pytest.ini --cov-config=fre/coveragerc --cov-report=xml --cov=fre fre/
+          
+          # install genbadge to generate coverage badge based on xml
+          pip install genbadge
+          genbadge coverage -v -i coverage.xml -o docs/cov_badge.svg
+          genbadge tests -v -i pytest_results.xml -o docs/pytest_badge.svg
+        
+      - name: Run pylint in fre-cli environment
+        run: |
+          # try to make sure the right things are in GITHUB_PATH
+          echo $CONDA/envs/fre-cli/bin >> $GITHUB_PATH
+
+          # are we talking to the right python?
+          which python
+          python --version
+          $CONDA/envs/fre-cli/bin/python --version
+          
+          # run pylint, ignored modules avoid warnings arising from code internal to those modules 
+          pylint --max-args 6 -ry --ignored-modules netCDF4,cmor fre/ || echo "pylint returned non-zero exit code. preventing workflow from dying with this echo."
 
       - name: Install Sphinx and Build Documentation
         run: |
@@ -72,7 +72,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
-#        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/contributing_to_doc.rst
+++ b/docs/contributing_to_doc.rst
@@ -20,7 +20,8 @@ How to Contribute to ``fre-cli``'s documentation
   nor interact with anything in that branch directly.
 
 
-2. enable workflows for your fork 
+2. enable workflows for your fork
+* note: this step may depend on user-specific settings!
 * Back on top where you found “settings”, find and click “actions” to the left
 * Enable running the workflow actions assoc with the ``fre-cli`` repo under ``.github/workflows``
 

--- a/docs/contributing_to_doc.rst
+++ b/docs/contributing_to_doc.rst
@@ -11,31 +11,34 @@ How to Contribute to ``fre-cli``'s documentation
 
 
 1. fork and poke at the settings
-* Fork ``fre-cli`` on github
-* On github, navigate to your ``fre-cli`` fork, and click “settings”
-* In “settings”, click “pages”
-* In “pages”, under “build and deployment”, make sure “source” is set to “Deploy from a branch”
-* Under that, find “Branch”, make sure the branch selected is ``gh-pages``. 
-* The branch ``gh-pages`` is “automagic”- i.e. do not change anything about it nor create a new one,
-  nor interact with anything in that branch directly.
+
+   * Fork ``fre-cli`` on github
+   * On github, navigate to your ``fre-cli`` fork, and click “settings”
+   * In “settings”, click “pages”
+   * In “pages”, under “build and deployment”, make sure “source” is set to “Deploy from a branch”
+   * Under that, find “Branch”, make sure the branch selected is ``gh-pages``. 
+   * The branch ``gh-pages`` is “automagic”- i.e. do not change anything about it nor create a new one,
+	 nor interact with anything in that branch directly.
 
 
 2. enable workflows for your fork
-* note: this step may depend on user-specific settings!
-* Back on top where you found “settings”, find and click “actions” to the left
-* Enable running the workflow actions assoc with the ``fre-cli`` repo under ``.github/workflows``
+
+   * note: this step may depend on user-specific settings!
+   * Back on top where you found “settings”, find and click “actions” to the left
+   * Enable running the workflow actions assoc with the ``fre-cli`` repo under ``.github/workflows``
 
 
 3. run your forks first workflow
-* The documentation builds as the last steps to ``create_test_conda_env.yml`` when theres a push to ``main``.
-  To get your first workflow run on your fork, comment out the ``github.ref == ‘refs/heads/main’`` bit
-  so that it runs when you push to any branch, and make a small, trivial, commit somewhere to your
-  remote fork.
-* You should be able to find the deployed webpage from a successful workflow at
-  https://your_username.github.io/fre-cli (if you did not change the fork’s name from ``fre-cli``, that is).
-* If you’re only editing docs, you can make the turn-around time on your workflow ~3 min faster by
-  commenting-out the ``pylint`` and ``pytest`` steps in ``create_test_conda_env.yml``, and disable running the
-  ``build_conda.yml`` workflow
+
+   * The documentation builds as the last steps to ``create_test_conda_env.yml`` when theres a push to ``main``.
+	 To get your first workflow run on your fork, comment out the ``github.ref == ‘refs/heads/main’`` bit
+	 so that it runs when you push to any branch, and make a small, trivial, commit somewhere to your
+	 remote fork.
+   * You should be able to find the deployed webpage from a successful workflow at
+	 https://your_username.github.io/fre-cli (if you did not change the fork’s name from ``fre-cli``, that is).
+   * If you’re only editing docs, you can make the turn-around time on your workflow ~3 min faster by
+   commenting-out the ``pylint`` and ``pytest`` steps in ``create_test_conda_env.yml``, and disable running the
+   ``build_conda.yml`` workflow
 
 
 

--- a/docs/contributing_to_doc.rst
+++ b/docs/contributing_to_doc.rst
@@ -37,8 +37,8 @@ How to Contribute to ``fre-cli``'s documentation
    * You should be able to find the deployed webpage from a successful workflow at
 	 https://your_username.github.io/fre-cli (if you did not change the fork’s name from ``fre-cli``, that is).
    * If you’re only editing docs, you can make the turn-around time on your workflow ~3 min faster by
-   commenting-out the ``pylint`` and ``pytest`` steps in ``create_test_conda_env.yml``, and disable running the
-   ``build_conda.yml`` workflow
+	 commenting-out the ``pylint`` and ``pytest`` steps in ``create_test_conda_env.yml``, and disable running the
+	 ``build_conda.yml`` workflow
 
 
 

--- a/docs/contributing_to_doc.rst
+++ b/docs/contributing_to_doc.rst
@@ -16,9 +16,9 @@ How to Contribute to ``fre-cli``'s documentation
    * On github, navigate to your ``fre-cli`` fork, and click “settings”
    * In “settings”, click “pages”
    * In “pages”, under “build and deployment”, make sure “source” is set to “Deploy from a branch”
-   * Under that, find “Branch”, make sure the branch selected is ``gh-pages``. 
-   * The branch ``gh-pages`` is “automagic”- i.e. do not change anything about it nor create a new one,
-	 nor interact with anything in that branch directly.
+   * Under that, find “Branch”, make sure the branch selected is ``gh-pages``
+   * The branch ``gh-pages`` is "automagic”- i.e. do not change anything about it nor create a new one,
+	 nor interact with anything in that branch directly
 
 
 2. enable workflows for your fork
@@ -28,14 +28,14 @@ How to Contribute to ``fre-cli``'s documentation
    * Enable running the workflow actions assoc with the ``fre-cli`` repo under ``.github/workflows``
 
 
-3. run your forks first workflow
+3. run your fork's first workflow
 
-   * The documentation builds as the last steps to ``create_test_conda_env.yml`` when theres a push to ``main``.
-	 To get your first workflow run on your fork, comment out the ``github.ref == ‘refs/heads/main’`` bit
+   * The documentation builds as the last steps to ``create_test_conda_env.yml`` when theres a push to ``main``
+   * To get your first workflow run on your fork, comment out the ``github.ref == ‘refs/heads/main’`` bit
 	 so that it runs when you push to any branch, and make a small, trivial, commit somewhere to your
-	 remote fork.
+	 remote fork
    * You should be able to find the deployed webpage from a successful workflow at
-	 https://your_username.github.io/fre-cli (if you did not change the fork’s name from ``fre-cli``, that is).
+	 https://your_username.github.io/fre-cli (if you did not change the fork’s name from ``fre-cli``, that is)
    * If you’re only editing docs, you can make the turn-around time on your workflow ~3 min faster by
 	 commenting-out the ``pylint`` and ``pytest`` steps in ``create_test_conda_env.yml``, and disable running the
 	 ``build_conda.yml`` workflow

--- a/docs/developer_usage.rst
+++ b/docs/developer_usage.rst
@@ -6,7 +6,7 @@ Developers are free to use the user guide above to familiarize with the CLI and 
 having to install any dependencies, but development within a Conda environment is heavily
 recommended regardless.
 
-Gain access to the repository with ``git clone git@github.com:NOAA-GFDL/fre-cli.git`` or your fork's
+Gain access to the repository with ``git clone --recursive git@github.com:NOAA-GFDL/fre-cli.git`` or your fork's
 link (recommended) and an SSH RSA key. Once inside the repository, developers can test local changes
 by running a ``pip install .`` inside of the root directory to install the ``fre-cli`` package locally
 with the newest local changes. Test as a normal user would use the CLI.
@@ -37,35 +37,35 @@ Checklist
 
 For the new tool you are trying to develop, there are a few criteria to satisfy
 
-1. Create a subdirectory for the tool group inside the ``fre/`` directory; i.e. ``fre/<subtool>``
+1. Create a subdirectory for the tool group inside the ``fre/`` directory; i.e. ``fre/<tool>``
 
-2. Add an ``__init__.py`` inside of ``fre/<subtool>`` 
+2. Add an ``__init__.py`` inside of ``fre/<tool>`` 
 
-* typically this file should be empty, but it depends on the ``<subtool>``'s needs
+* typically this file should be empty, but it depends on the ``<tool>``'s needs
 * even if empty, the file facillitates module importability and must be present
 
-3. Add a file named ``fre/<subtool>/fre<subtool>.py``. This will serve as the main entry point for ``fre``
-   into the ``<subtool>``'s functionality
+3. Add a file named ``fre/<tool>/fre<tool>.py``. This will serve as the main entry point for ``fre``
+   into the ``<tool>``'s functionality
 
-4. Add a ``click`` group named after ``<subtool>`` within ``fre/<subtool>/fre<subtool>.py``
+4. Add a ``click`` group named after ``<tool>`` within ``fre/<tool>/fre<tool>.py``
 
-* This ``click`` group will contain all the subcommands under the ``<subtool>``'s functionality
+* This ``click`` group will contain all the subcommands under the ``<tool>``'s functionality
 
 5. Create separate files as needed for different subcommands; do not code out the full
-   implemetation of ``<subtool>`` inside of a ``click`` command within ``fre/<subtool>/fre<subtool>.py``.
+   implemetation of ``<tool>`` inside of a ``click`` command within ``fre/<tool>/fre<tool>.py``.
 
 * better yet, consider what structure your subtool may need in the future for maintainability's sake
 
-6. Be sure to import the contents of the needed subcommand scripts inside of ``fre<subtool>.py``
+6. Be sure to import the contents of the needed subcommand scripts inside of ``fre<tool>.py``
 
-* i.e. from ``fre.fre<subtool>.subCommandScript import *``
+* i.e. from ``fre.fre<tool>.subCommandScript import *``
 
 7. At this point, you can copy and paste the parts of your main ``click`` subcommand from its script
-   into ``fre<subtool>.py`` when implementing the function reflective of the subcommand function
+   into ``fre<tool>.py`` when implementing the function reflective of the subcommand function
 
 * Everything will remain the same; i.e. arguments, options, etc.
 
-* However, this new function within ``fre<subtool>.py`` must a new line after the arguments, options,
+* However, this new function within ``fre<tool>.py`` must a new line after the arguments, options,
   and other command components; ``@click.pass_context``
 
 * Along with this, a new argument ``context`` must now be added to the parameters of the command
@@ -74,12 +74,12 @@ For the new tool you are trying to develop, there are a few criteria to satisfy
 8. From here, all that needs to be added after defining the command with a name is
    ``context.forward(mainFunctionOfSubcommand)``, and done!
 
-9. After this step, it is important to add ``from fre.fre<subtool> import`` to ``__init__.py``
+9. After this step, it is important to add ``from fre.fre<tool> import`` to ``__init__.py``
    within the /fre folder
 
-10. The last step is to replicate the subcommand in the same way as done in ``fre<subtool>.py``
-	inside of ``fre.py``, but make sure to add ``from fre import fre<subtool>`` and
-	``from fre.fre<subtool>.fre<subtool> import *``
+10. The last step is to replicate the subcommand in the same way as done in ``fre<tool>.py``
+	inside of ``fre.py``, but make sure to add ``from fre import fre<tool>`` and
+	``from fre.fre<tool>.fre<tool> import *``
 
 Please refer to this issue when encountering naming issues:
 `NOAA-GFDL#31 <https://github.com/NOAA-GFDL/fre-cli/issues/31>`_
@@ -91,10 +91,10 @@ Example ``fre/`` Directory Structure
 ``fre/``
 ├── ``__init__.py``
 ├── ``fre.py``
-├── ``fre<subtool>``
+├── ``fre<tool>``
 │   ├── ``__init__.py``
-│   ├── ``subCommandScript.py``
-│   └── ``fre<subtool>.py``
+│   ├── ``toolCommandScript.py``
+│   └── ``fre<tool>.py``
 
 
 ``MANIFEST.in``
@@ -102,10 +102,10 @@ Example ``fre/`` Directory Structure
 
 In the case where non-python files like templates, examples, and outputs are to be included in the ``fre-cli`` package,
 ``MANIFEST.in`` can provide the solution. Ensure that the file exists within the correct folder, and add a line to the
-``MANIFEST.in`` file saying something like ``include fre/fre<subtool>/fileName.fileExtension``
+``MANIFEST.in`` file saying something like ``include fre/fre<tool>/fileName.fileExtension``
 
 * For more efficiency, if there are multiple files of the same type needed, the ``MANIFEST.in`` addition can be something
-  like ``recursive-include fre/fre<subtool> *.fileExtension`` which would recursively include every file matching that
+  like ``recursive-include fre/fre<tool> *.fileExtension`` which would recursively include every file matching that
   ``fileExtension`` within the specified directory and its respective subdirectories.
 
 

--- a/docs/fre_app.rst
+++ b/docs/fre_app.rst
@@ -1,0 +1,2 @@
+1. ``generate-time-averages``
+2. ``regrid_xy``

--- a/docs/fre_catalog.rst
+++ b/docs/fre_catalog.rst
@@ -1,0 +1,8 @@
+1. ``builder`` Generate a catalog
+
+* Builds json and csv format catalogs from user input directory path
+* Minimal Syntax: ``fre catalog builder -i [input path] -o [output path]``
+* Module(s) needed: n/a
+* Example: ``fre catalog builder -i /archive/am5/am5/am5f3b1r0/c96L65_am5f3b1r0_pdclim1850F/gfdl.ncrc5-deploy-prod-openmp/pp -o ~/output --overwrite``
+
+2. ``validate`` Validate the catalog

--- a/docs/fre_cmor.rst
+++ b/docs/fre_cmor.rst
@@ -1,3 +1,3 @@
 1. ``run``
 
-* placehold
+

--- a/docs/fre_cmor.rst
+++ b/docs/fre_cmor.rst
@@ -1,0 +1,3 @@
+1. ``run``
+
+* placehold

--- a/docs/fre_make.rst
+++ b/docs/fre_make.rst
@@ -1,0 +1,3 @@
+1. ``run-fremake``
+
+* placehold

--- a/docs/fre_pp.rst
+++ b/docs/fre_pp.rst
@@ -1,0 +1,13 @@
+1. ``configure`` 
+
+* Postprocessing yaml configuration
+* Minimal Syntax: ``fre pp configure -y [user-edit yaml file]``
+* Module(s) needed: n/a
+* Example: ``fre pp configure -y /home/$user/pp/ue2/user-edits/edits.yaml``
+
+2. ``checkout``
+
+* Checkout template file and clone gitlab.gfdl.noaa.gov/fre2/workflows/postprocessing.git repository
+* Minimal Syntax: ``fre pp checkout -e [experiment name] -p [platform name] -t [target name]``
+* Module(s) needed: n/a
+* Example: ``fre pp checkout -e c96L65_am5f4b4r0_amip -p gfdl.ncrc5-deploy -t prod-openmp``

--- a/docs/fre_yamltools.rst
+++ b/docs/fre_yamltools.rst
@@ -1,0 +1,3 @@
+1. ``combine-yamls``
+
+* placehold

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -52,9 +52,8 @@ fre catalog
 fre cmor
 --------
 
-1. ``run``
+.. include:: fre_cmor.rst
 
-* placehold
 
   
 fre make

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -23,30 +23,21 @@ Brief rundown of commands also provided below:
   *entry point*. Without it, the call would be instead, something like ``python fre/fre.py``
 
 
-Tools
-=====
-
-A few subtools are currently in development:
+Usage-By-Tool
+=============
 
 
 fre app
 -------
 
-1. ``generate-time-averages``
-2. ``regrid_xy``
+.. include:: fre_app.rst
+
 
    
 fre catalog
 -----------
 
-1. ``builder`` Generate a catalog
-
-* Builds json and csv format catalogs from user input directory path
-* Minimal Syntax: ``fre catalog builder -i [input path] -o [output path]``
-* Module(s) needed: n/a
-* Example: ``fre catalog builder -i /archive/am5/am5/am5f3b1r0/c96L65_am5f3b1r0_pdclim1850F/gfdl.ncrc5-deploy-prod-openmp/pp -o ~/output --overwrite``
-
-2. ``validate`` Validate the catalog
+.. include:: fre_catalog.rst
 
 
 fre cmor
@@ -54,40 +45,23 @@ fre cmor
 
 .. include:: fre_cmor.rst
 
-
   
 fre make
 --------
 
-1. ``run-fremake``
-
-* placehold
-
+.. include:: fre_make.rst
   
+
 fre pp
 ------
 
-1. ``configure`` 
-
-* Postprocessing yaml configuration
-* Minimal Syntax: ``fre pp configure -y [user-edit yaml file]``
-* Module(s) needed: n/a
-* Example: ``fre pp configure -y /home/$user/pp/ue2/user-edits/edits.yaml``
-
-2. ``checkout``
-
-* Checkout template file and clone gitlab.gfdl.noaa.gov/fre2/workflows/postprocessing.git repository
-* Minimal Syntax: ``fre pp checkout -e [experiment name] -p [platform name] -t [target name]``
-* Module(s) needed: n/a
-* Example: ``fre pp checkout -e c96L65_am5f4b4r0_amip -p gfdl.ncrc5-deploy -t prod-openmp``
+.. include:: fre_pp.rst
 
 
 fre yamltools
 -------------
 
-1. ``combine-yamls``
-
-* placehold
+.. include:: fre_yamltools.rst
 
 
 not-yet-implemented

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -27,49 +27,61 @@ Usage-By-Tool
 =============
 
 
-fre app
--------
+``fre app``
+-----------
 
 .. include:: fre_app.rst
 
-
    
-fre catalog
------------
+``fre catalog``
+---------------
 
 .. include:: fre_catalog.rst
 
 
-fre cmor
---------
+``fre cmor``
+------------
 
 .. include:: fre_cmor.rst
 
   
-fre make
---------
+``fre make``
+------------
 
 .. include:: fre_make.rst
   
 
-fre pp
-------
+``fre pp``
+----------
 
 .. include:: fre_pp.rst
 
 
-fre yamltools
--------------
+``fre yamltools``
+-----------------
 
 .. include:: fre_yamltools.rst
 
 
-not-yet-implemented
--------------------
+Tools Not-Yet-Implemented
+=========================
 
-#. ``fre check``
-#. ``fre list``
-#. ``fre run``
-#. ``fre test``
+``fre check``
+-------------
 
+to-do
 
+``fre list``
+------------
+
+to-do
+
+``fre run``
+-----------
+
+to-do
+
+``fre test``
+------------
+
+to-do


### PR DESCRIPTION
`fre cmor` doc updates being pushed to `ilaflott::update-fre-cmor-doc3`. this being cannibalized for useful `include` structure in `reStructuredText`

------------------------


~~focusing on `fre cmor` functionality here more explicitly, having lopped off #254 after some good general changes.~~

see preview of doc page at my [fork's gh-pages](https://ilaflott.github.io/ians_fre_cli/)

