### PR TITLE
add container buildscript creation for `createDockerfile`

### DIFF
--- a/fre/make/createDocker.py
+++ b/fre/make/createDocker.py
@@ -72,10 +72,13 @@ def dockerfile_create(yamlfile,platform,target,execute):
                 click.echo("\ntmpDir created in " + currDir + "/tmp")
                 click.echo("Dockerfile created in " + currDir +"\n")
 
-            if run:
-                dockerBuild.build(containerBuild, containerRun)
-            else:
-                sys.exit()
+                # create build script for container
+                dockerBuild.createBuildScript(containerBuild, containerRun)
+                print("Container build script created at "+dockerBuild.userScriptPath+"\n\n")
+
+                # run the script if option is given
+                if run:
+                    subprocess.run(args=[dockerBuild.userScriptPath], check=True)
 
 @click.command()
 def _dockerfile_create(yamlfile,platform,target,execute):

--- a/fre/make/createDocker.py
+++ b/fre/make/createDocker.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import subprocess
 from pathlib import Path
 import click
 #from .gfdlfremake import varsfre, targetfre, makefilefre, platformfre, yamlfre, buildDocker


### PR DESCRIPTION
## Describe your changes
Updates the `createDockerfile` fremake subcommand to create a short container build script instead of running commands directly.

I also added another level of indents so it'll only create the build script/run if the `if iscontainer` conditional is true like the commands above it. I think it needs the commands above it for the build script to work properly, but I don't really know how multiplatform builds work so let me know if it should be moved back.

This needs #271 in first, which adds the same functionality to run-fremake with container builds.

## Issue ticket number and link (if applicable)

## Checklist before requesting a review

- [ ] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
