### PR TITLE
Fix print statement to reflect full path to combined yaml

### DIFF
--- a/fre/yamltools/combine_yamls.py
+++ b/fre/yamltools/combine_yamls.py
@@ -203,7 +203,7 @@ class init_compile_yaml():
         with open(self.combined,'w',encoding='UTF-8') as f:
             yaml.safe_dump(full_yaml,f,default_flow_style=False,sort_keys=False)
 
-        print(f"Combined yaml located here: {os.path.dirname(self.combined)}/{self.combined}")
+        print(f"Combined yaml located here: {os.path.abspath(self.combined)}")
         return self.combined
 
 ## PP CLASS ##

--- a/fre/yamltools/combine_yamls.py
+++ b/fre/yamltools/combine_yamls.py
@@ -299,7 +299,7 @@ class init_pp_yaml():
         with open(self.combined,'w') as f:
             yaml.safe_dump(full_yaml,f,default_flow_style=False,sort_keys=False)
 
-        print(f"Combined yaml located here: {os.path.dirname(self.combined)}/{self.combined}")
+        print(f"Combined yaml located here: {os.path.abspath(self.combined)}")
         return self.combined
 
 ## Functions to combine the yaml files ##


### PR DESCRIPTION
## Describe your changes
The print statement for created combined yaml for post-processing was showing an incorrect location to the combined yaml. This prints the absolute path to the yaml now. 

## Issue ticket number and link (if applicable)

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [x] I ran pylint and attempted to implement some of it's feedback
