### PR TITLE
 Fix click decorator calls

### DIFF
--- a/fre/pp/configure_script_xml.py
+++ b/fre/pp/configure_script_xml.py
@@ -685,11 +685,11 @@ def _convert(xml, platform, target, experiment, do_analysis=False, historydir=No
 ##############################################
 
 @click.command()
-def convert():
+def _convert():
     '''
     Wrapper for convert call - allows users to call without command-line args
     '''
-    _convert()
+    convert()
 
 if __name__ == '__main__':
     convert()

--- a/fre/pp/frepp.py
+++ b/fre/pp/frepp.py
@@ -32,7 +32,7 @@ def pp_cli():
 def status(context, experiment, platform, target):
     # pylint: disable=unused-argument
     """ - Report status of PP configuration"""
-    context.forward(status_script.status_subtool)
+    context.forward(status_script._status_subtool)
 
 # fre pp run
 @pp_cli.command()
@@ -49,7 +49,7 @@ def status(context, experiment, platform, target):
 def run(context, experiment, platform, target):
     # pylint: disable=unused-argument
     """ - Run PP configuration"""
-    context.forward(run_script.pp_run_subtool)
+    context.forward(run_script._pp_run_subtool)
 
 # fre pp validate
 @pp_cli.command()
@@ -83,7 +83,7 @@ def validate(context, experiment, platform, target):
 def install(context, experiment, platform, target):
     # pylint: disable=unused-argument
     """ - Install PP configuration"""
-    context.forward(install_script.install_subtool)
+    context.forward(install_script._install_subtool)
 
 @pp_cli.command()
 @click.option("-y", "--yamlfile", type=str,
@@ -179,7 +179,7 @@ def configure_xml(context, xml, platform, target, experiment, do_analysis, histo
                   ppdir, do_refinediag, pp_start, pp_stop, validate, verbose, quiet, dual):
     # pylint: disable=unused-argument
     """ - Converts a Bronx XML to a Canopy rose-suite.conf """
-    context.forward(configure_script_xml.convert)
+    context.forward(configure_script_xml._convert)
 
 #fre pp wrapper
 @pp_cli.command()

--- a/fre/pp/install_script.py
+++ b/fre/pp/install_script.py
@@ -38,4 +38,4 @@ def install_subtool(experiment, platform, target):
 @click.command()
 def _install_subtool(experiment, platform, target):
     ''' entry point to install for click '''
-    return _install_subtool(experiment, platform, target)
+    return install_subtool(experiment, platform, target)


### PR DESCRIPTION
## Describe your changes
The click decorator function for the install subtool was not being called properly in `install.py`.  Fixed the click decorator function and anywhere else I saw the same issue. 

## Issue ticket number and link (if applicable)
N/A

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
