### PR TITLE
 Fix error message for incorrect platform used

### DIFF
--- a/fre/make/create_compile_script.py
+++ b/fre/make/create_compile_script.py
@@ -56,7 +56,7 @@ def compile_create(yamlfile,platform,target,jobs,parallel,execute,verbose):
          if modelYaml.platforms.hasPlatform(platformName):
               pass
          else:
-              raise ValueError (platformName + " does not exist in " + modelYaml.combined.get("compile").get("platformYaml"))
+              raise ValueError (platformName + " does not exist in platforms.yaml")
 
          platform=modelYaml.platforms.getPlatformFromName(platformName)
          ## Make the bldDir based on the modelRoot, the platform, and the target

--- a/fre/make/create_compile_script.py
+++ b/fre/make/create_compile_script.py
@@ -56,7 +56,7 @@ def compile_create(yamlfile,platform,target,jobs,parallel,execute,verbose):
          if modelYaml.platforms.hasPlatform(platformName):
               pass
          else:
-              raise ValueError (platformName + " does not exist in platforms.yaml")
+              raise ValueError (f"{platformName} does not exist in platforms.yaml")
 
          platform=modelYaml.platforms.getPlatformFromName(platformName)
          ## Make the bldDir based on the modelRoot, the platform, and the target

--- a/fre/make/create_docker_script.py
+++ b/fre/make/create_docker_script.py
@@ -42,7 +42,7 @@ def dockerfile_create(yamlfile,platform,target,execute):
             if modelYaml.platforms.hasPlatform(platformName):
                 pass
             else:
-                raise ValueError (platform_name + " does not exist in platforms.yaml")
+                raise ValueError (platformName + " does not exist in platforms.yaml")
 
             platform = modelYaml.platforms.getPlatformFromName(platformName)
 

--- a/fre/make/create_docker_script.py
+++ b/fre/make/create_docker_script.py
@@ -42,7 +42,7 @@ def dockerfile_create(yamlfile,platform,target,execute):
             if modelYaml.platforms.hasPlatform(platformName):
                 pass
             else:
-                raise ValueError (platformName + " does not exist in platforms.yaml")
+                raise ValueError (f"{platformName} does not exist in platforms.yaml")
 
             platform = modelYaml.platforms.getPlatformFromName(platformName)
 

--- a/fre/make/create_docker_script.py
+++ b/fre/make/create_docker_script.py
@@ -42,8 +42,7 @@ def dockerfile_create(yamlfile,platform,target,execute):
             if modelYaml.platforms.hasPlatform(platformName):
                 pass
             else:
-                raise ValueError (platformName + " does not exist in " + \
-                                  modelYaml.combined.get("compile").get("platformYaml"))
+                raise ValueError (platform_name + " does not exist in platforms.yaml")
 
             platform = modelYaml.platforms.getPlatformFromName(platformName)
 

--- a/fre/make/create_makefile_script.py
+++ b/fre/make/create_makefile_script.py
@@ -39,7 +39,7 @@ def makefile_create(yamlfile,platform,target):
             if modelYaml.platforms.hasPlatform(platformName):
                 pass
             else:
-                raise ValueError (platformName + " does not exist in " + modelYaml.combined.get("compile").get("platformYaml"))
+                raise ValueError (platformName + " does not exist in platforms.yaml")
 
             platform=modelYaml.platforms.getPlatformFromName(platformName)
   ## Make the bldDir based on the modelRoot, the platform, and the target

--- a/fre/make/create_makefile_script.py
+++ b/fre/make/create_makefile_script.py
@@ -9,6 +9,9 @@ from .gfdlfremake import makefilefre, varsfre, targetfre, yamlfre
 import fre.yamltools.combine_yamls as cy
 
 def makefile_create(yamlfile,platform,target):
+    """
+    Create the makefile
+    """
     srcDir="src"
     checkoutScriptName = "checkout.sh"
     baremetalRun = False # This is needed if there are no bare metal runs
@@ -39,7 +42,7 @@ def makefile_create(yamlfile,platform,target):
             if modelYaml.platforms.hasPlatform(platformName):
                 pass
             else:
-                raise ValueError (platformName + " does not exist in platforms.yaml")
+                raise ValueError (f"{platformName} does not exist in platforms.yaml")
 
             platform=modelYaml.platforms.getPlatformFromName(platformName)
   ## Make the bldDir based on the modelRoot, the platform, and the target

--- a/fre/make/run_fremake_script.py
+++ b/fre/make/run_fremake_script.py
@@ -69,7 +69,7 @@ def fremake_run(yamlfile,platform,target,parallel,jobs,no_parallel_checkout,exec
         if modelYaml.platforms.hasPlatform(platformName):
             pass
         else:
-            raise ValueError (platformName + " does not exist in platforms.yaml")
+            raise ValueError (f"{platformName} does not exist in platforms.yaml")
 
         platform = modelYaml.platforms.getPlatformFromName(platformName)
 

--- a/fre/make/run_fremake_script.py
+++ b/fre/make/run_fremake_script.py
@@ -69,8 +69,7 @@ def fremake_run(yamlfile,platform,target,parallel,jobs,no_parallel_checkout,exec
         if modelYaml.platforms.hasPlatform(platformName):
             pass
         else:
-            raise ValueError(f'{platformName} does not exist in '
-                             f'{modelYaml.combined.get("compile").get("platformYaml")}')
+            raise ValueError (platformName + " does not exist in platforms.yaml")
 
         platform = modelYaml.platforms.getPlatformFromName(platformName)
 


### PR DESCRIPTION
## Describe your changes
If an incorrect platform was passed with the fre make commands, there was a very informative error raised. This fixes the error message to basically say "the platform passed doesn't exists in the platforms.yaml"

## Issue ticket number and link (if applicable)

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
