### PR TITLE
change `conda build` source back to `path: .` from `url: <repo url>`

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -4,6 +4,7 @@ package:
   name: fre-cli
   version: '{{ environ.get("GIT_DESCRIBE_TAG", data.get("version")) }}'
 
+# conda-build will always defer to what's specified here
 source:
   path: .
 #  git_url: https://github.com/NOAA-GFDL/fre-cli.git


### PR DESCRIPTION
## Describe your changes
apparently `conda build .` will not listen to the `.` part and defer to what is under the `source:` key within `meta.yaml`.

so if we run `conda build .` followed by `conda publish` in `.github/workflows/publish_conda.yml`, we're publishing old code into the package channel, and not the code that's being merged into `main` from a PR, no buéno.

## Issue ticket number and link (if applicable)
see [this PR comment and following pipeline outcomes](https://github.com/NOAA-GFDL/fre-cli/pull/303#issuecomment-2561332908)

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
~~- [ ] I wrote a new test, if applicable~~
~~- [ ] I wrote new instructions/documentation, if applicable~~
- [x] I ran pytest and inspected it's output
~~- [ ] I ran pylint and attempted to implement some of it's feedback~~
