### PR TITLE
Updates to 'fre pp run' to account for delay in starting Cylc scheduler

### DIFF
--- a/fre/pp/run_script.py
+++ b/fre/pp/run_script.py
@@ -1,6 +1,7 @@
 ''' fre pp run '''
 
 import subprocess
+import time
 import click
 
 def pp_run_subtool(experiment, platform, target):
@@ -9,9 +10,24 @@ def pp_run_subtool(experiment, platform, target):
     <experiment>__<platform>__<target>
     """
 
+    # Check to see if the workflow is already running
     name = experiment + '__' + platform + '__' + target
+    result = subprocess.run(['cylc', 'scan', '--name', f"^{name}$"], capture_output=True).stdout.decode('utf-8')
+    if len(result):
+        print("Workflow already running!")
+        return
+
+    # If not running, start it
     cmd = f"cylc play {name}"
     subprocess.run(cmd, shell=True, check=True)
+
+    # wait 30 seconds for the scheduler to come up; then confirm
+    print("Workflow started; waiting 30 seconds to confirm")
+    time.sleep(30)
+    result = subprocess.run(['cylc', 'scan', '--name', f"^{name}$"], capture_output=True).stdout.decode('utf-8')
+
+    if not len(result):
+        raise Exception('Cylc scheduler was started without error but is not running after 30 seconds')
 
 @click.command()
 def _pp_run_subtool(experiment, platform, target):


### PR DESCRIPTION
## Describe your changes
- check to see if the scheduler is already up; if so exit right away with success
- otherwise, sleep 30 seconds, then confirm the scheduler is actually up
- if not, error 30 seconds was chosen based on hand-testing and might have to be adjusted later

## Issue ticket number and link (if applicable)
#317

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
~~- [ ] I wrote a new test, if applicable~~ (calls to `cylc` are not yet testable presently)
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
