### PR TITLE
fix badge updating

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ Welcome to ``fre-cli``'s documentation!
    tools
    api
    for-developers
+   badges
 
 Indices
 =======


### PR DESCRIPTION
put `badges` back into `docs/index.rst`, as the README.md badge displaying/updating is dependent upon that page being rendered in `gh-pages`

## Checklist before requesting a review

- [ ] I ran my code
~~- [ ] I tried to make my code readable~~
~~- [ ] I tried to comment my code~~
~~- [ ] I wrote a new test, if applicable~~
~~- [ ] I wrote new instructions/documentation, if applicable~~
~~- [ ] I ran pytest and inspected it's output~~
~~- [ ] I ran pylint and attempted to implement some of it's feedback~~
