### PR TITLE
Update package version to 2025.01.01

### DIFF
--- a/fre/cmor/cmor_mixer.py
+++ b/fre/cmor/cmor_mixer.py
@@ -17,7 +17,7 @@ import cmor
 from .cmor_helpers import *
 
 # ----- \start consts # TODO make this an input argument flag or smth.
-DEBUG_MODE_RUN_ONE = True
+DEBUG_MODE_RUN_ONE = False
 # ----- \end consts
 
 

--- a/fre/fre.py
+++ b/fre/fre.py
@@ -22,13 +22,14 @@ if len(version_unexpanded_split[1]) == 1:
 else:
     version_minor = version_unexpanded_split[1]
 # if the patch version is present, then use it. otherwise, omit
-if '2' in range(len(version_unexpanded_split)):
+try:
+    len(version_unexpanded_split[2])
     if len(version_unexpanded_split[2]) == 1:
         version_patch = "0" + version_unexpanded_split[2]
     else:
         version_patch = version_unexpanded_split[2]
     version = version_unexpanded_split[0] + '.' + version_minor + '.' + version_patch
-else:
+except IndexError:
     version = version_unexpanded_split[0] + '.' + version_minor
 
 # click and lazy group loading

--- a/fre/fre.py
+++ b/fre/fre.py
@@ -21,7 +21,15 @@ if len(version_unexpanded_split[1]) == 1:
     version_minor = "0" + version_unexpanded_split[1]
 else:
     version_minor = version_unexpanded_split[1]
-version = version_unexpanded_split[0] + '.' + version_minor
+# if the patch version is present, then use it. otherwise, omit
+if '2' in range(len(version_unexpanded_split)):
+    if len(version_unexpanded_split[2]) == 1:
+        version_patch = "0" + version_unexpanded_split[2]
+    else:
+        version_patch = version_unexpanded_split[2]
+    version = version_unexpanded_split[0] + '.' + version_minor + '.' + version_patch
+else:
+    version = version_unexpanded_split[0] + '.' + version_minor
 
 # click and lazy group loading
 @click.group(

--- a/fre/tests/test_fre_cli.py
+++ b/fre/tests/test_fre_cli.py
@@ -24,11 +24,11 @@ def test_cli_fre_option_dne():
 
 def test_fre_version():
     ''' module import flavor of below cli test '''
-    assert '2025.01' == fre.version
+    assert '2025.01.01' == fre.version
 
 def test_cli_fre_version():
     ''' fre --version '''
     result = runner.invoke(fre.fre, args='--version')
-    expected_out = 'fre, version 2025.01'
+    expected_out = 'fre, version 2025.01.01'
     assert all( [ result.exit_code == 0,
                   expected_out in result.stdout.split('\n') ] )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='fre-cli',
-    version='2025.01',
+    version='2025.01.01',
     description='Command Line Interface for FRE commands',
     author='MSD Workflow Team, Bennett Chang, Dana Singh, Chris Blanton',
     author_email='oar.gfdl.workflow@noaa.gov',


### PR DESCRIPTION
## Describe your changes
Traditionally, we do not update the package version often, but new updates are re-published to the noaa-gfdl anaconda channel with the same version.

https://anaconda.org/NOAA-GFDL/fre-cli

However, in the last few weeks the publishing pipeline has not updated as expected. So let's bump the minor package version and see if it builds and deploys.

## Issue ticket number and link (if applicable)

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
