### PR TITLE
 #221 Add force-compile functionality

### DIFF
--- a/fre/make/create_compile_script.py
+++ b/fre/make/create_compile_script.py
@@ -1,16 +1,42 @@
 '''
-TODO: make docstring
+Create the compile script to compile model
 '''
 import os
 import sys
 import logging
 from pathlib import Path
 from multiprocessing.dummy import Pool
+import subprocess
 
 from .gfdlfremake import varsfre, yamlfre, targetfre, buildBaremetal
 import fre.yamltools.combine_yamls as cy
 
-def compile_create(yamlfile, platform, target, jobs, parallel, execute, verbose):
+def compile_script_write_steps(yaml_obj,mkTemplate,src_dir,bld_dir,target,modules,modulesInit,jobs):
+    """
+    Go through steps to create the compile script
+    """
+    ## Create a list of compile scripts to run in parallel
+    fremakeBuild = buildBaremetal.buildBaremetal(exp = yaml_obj["experiment"],
+                                                 mkTemplatePath = mkTemplate,
+                                                 srcDir = src_dir,
+                                                 bldDir = bld_dir,
+                                                 target = target,
+                                                 modules = modules,
+                                                 modulesInit = modulesInit,
+                                                 jobs = jobs)
+    for c in yaml_obj['src']:
+        fremakeBuild.writeBuildComponents(c)
+    fremakeBuild.writeScript()
+
+    print("    Compile script created here: " + bld_dir + "/compile.sh" + "\n")
+    compile_script = f"{bld_dir}/compile.sh"
+
+    return compile_script
+
+def compile_create(yamlfile,platform,target,jobs,parallel,execute,verbose,force_compile):
+    """
+    Create the compile script
+    """
     # Define variables
     yml = yamlfile
     name = yamlfile.split(".")[0]
@@ -18,12 +44,12 @@ def compile_create(yamlfile, platform, target, jobs, parallel, execute, verbose)
     jobs = str(jobs)
 
     if verbose:
-      logging.basicCOnfig(level=logging.INFO)
+      logging.basicConfig(level=logging.INFO)
     else:
       logging.basicConfig(level=logging.ERROR)
 
-    srcDir="src"
-    checkoutScriptName = "checkout.sh"
+    src_dir="src"
+    checkout_script_name = "checkout.sh"
     baremetalRun = False # This is needed if there are no bare metal runs
 
     ## Split and store the platforms and targets in a list
@@ -38,10 +64,10 @@ def compile_create(yamlfile, platform, target, jobs, parallel, execute, verbose)
     full_combined = cy.combined_compile_existcheck(combined,yml,platform,target)
 
     ## Get the variables in the model yaml
-    freVars = varsfre.frevars(full_combined)
+    fre_vars = varsfre.frevars(full_combined)
 
     ## Open the yaml file and parse as fremakeYaml
-    modelYaml = yamlfre.freyaml(full_combined,freVars)
+    modelYaml = yamlfre.freyaml(full_combined,fre_vars)
     fremakeYaml = modelYaml.getCompileYaml()
 
     ## Error checking the targets
@@ -60,31 +86,49 @@ def compile_create(yamlfile, platform, target, jobs, parallel, execute, verbose)
 
          platform=modelYaml.platforms.getPlatformFromName(platformName)
          ## Make the bldDir based on the modelRoot, the platform, and the target
-         srcDir = platform["modelRoot"] + "/" + fremakeYaml["experiment"] + "/src"
+         src_dir = platform["modelRoot"] + "/" + fremakeYaml["experiment"] + "/src"
          ## Check for type of build
          if platform["container"] is False:
               baremetalRun = True
-              bldDir = platform["modelRoot"] + "/" + fremakeYaml["experiment"] + "/" + platformName + "-" + target.gettargetName() + "/exec"
-              os.system("mkdir -p " + bldDir)
-              ## Create a list of compile scripts to run in parallel
-              fremakeBuild = buildBaremetal.buildBaremetal(exp = fremakeYaml["experiment"],
-                                                       mkTemplatePath = platform["mkTemplate"],
-                                                       srcDir = srcDir,
-                                                       bldDir = bldDir,
-                                                       target = target,
-                                                       modules = platform["modules"],
-                                                       modulesInit = platform["modulesInit"],
-                                                       jobs = jobs)
-              for c in fremakeYaml['src']:
-                   fremakeBuild.writeBuildComponents(c)
-              fremakeBuild.writeScript()
-              fremakeBuildList.append(fremakeBuild)
-              print("\nCompile script created at " + bldDir + "/compile.sh" + "\n")
+              bld_dir = platform["modelRoot"] + "/" + fremakeYaml["experiment"] + "/" + platformName + "-" + target.gettargetName() + "/exec"
+              os.system("mkdir -p " + bld_dir)
+              if not os.path.exists(bld_dir+"/compile.sh"):
+                  print("\nCreating the compile script...")
+                  fremakeBuild = compile_script_write_steps(yaml_obj = fremakeYaml,
+                                                            mkTemplate = platform["mkTemplate"],
+                                                            src_dir = src_dir,
+                                                            bld_dir = bld_dir,
+                                                            target = target,
+                                                            modules = platform["modules"],
+                                                            modulesInit = platform["modulesInit"],
+                                                            jobs = jobs)
+                  # Append the compile script created
+                  fremakeBuildList.append(fremakeBuild)
+              else:
+                  if force_compile:
+                      # Remove compile script
+                      os.remove(bld_dir + "/compile.sh")
+                      # Re-create compile script
+                      print("\nRe-creating the compile script...")
+                      fremakeBuild = compile_script_write_steps(yaml_obj = fremakeYaml,
+                                                                mkTemplate = platform["mkTemplate"],
+                                                                src_dir = src_dir,
+                                                                bld_dir = bld_dir,
+                                                                target = target,
+                                                                modules = platform["modules"],
+                                                                modulesInit = platform["modulesInit"],
+                                                                jobs = jobs)
+                      # Append the returned compile script created
+                      fremakeBuildList.append(fremakeBuild)
+                  else:
+                      print("Compile script PREVIOUSLY created here: " + bld_dir + "/compile.sh" + "\n")
+                      # Append the compile script
+                      fremakeBuildList.append(f"{bld_dir}/compile.sh")
 
     if execute:
         if baremetalRun:
-            pool = Pool(processes=nparallel)                         # Create a multiprocessing Pool
-            pool.map(buildBaremetal.fremake_parallel,fremakeBuildList)  # process data_inputs iterable with pool
+            pool = Pool(processes=nparallel)                            # Create a multiprocessing Pool
+            pool.map(buildBaremetal.run,fremakeBuildList)  # process data_inputs iterable with pool
     else:
         return
 

--- a/fre/make/fremake.py
+++ b/fre/make/fremake.py
@@ -27,8 +27,12 @@ The default is to have parallel checkouts.
 """
 VERBOSE_OPT_HELP = """Get verbose messages (repeat the option to increase verbosity level)
 """
-
-
+FORCE_CHECKOUT_OPT_HELP = """Force checkout in case the source directory exists.
+"""
+FORCE_COMPILE_OPT_HELP = """Force compile in case the executable directory exists.
+"""
+FORCE_DOCKERFILE_OPT_HELP = """Force dockerfile creation in case dockerfile exists.
+"""
 
 @click.group(help=click.style(" - access fre make subcommands", fg=(210,73,57)))
 def make_cli():
@@ -175,10 +179,24 @@ def create_makefile(yamlfile, platform, target):
               "--verbose",
               is_flag = True,
               help = VERBOSE_OPT_HELP)
-def create_compile(yamlfile, platform, target, jobs, parallel, execute, verbose):
-    """ - Write the compile script """
-    create_compile_script.compile_create(
-        yamlfile, platform, target, jobs, parallel, execute, verbose)
+@click.option("-F",
+              "--force-compile",
+              is_flag=True,
+              help = FORCE_COMPILE_OPT_HELP)
+def create_compile(yamlfile, platform, target, jobs, parallel, execute, verbose, force_compile):
+    """ 
+    - Write the compile script\n
+    - For --target use: Predefined targets refer to groups of directives that exist in the mkmf template file.\n
+          Possible predefined targets include 'prod','openmp', 'repro', 'debug, 'hdf5';
+however 'prod', 'repro', and 'debug' are mutually exclusive (cannot not use more than one 
+of these in the target list). Any number of targets can be used.\n
+    - Use `--force-compile` to compile a fresh executable.\n
+          An existing executable directory is normally reused if possible. It's an error if 
+current compile instructions don't match the experiment suite configuration file UNLESS the 
+option --force-compile is used. This option allows the user to recreate the compile script 
+according to the current configuration file.
+    """
+    create_compile_script.compile_create(yamlfile,platform,target,jobs,parallel,execute,verbose,force_compile)
 
 @make_cli.command
 @click.option("-y",

--- a/fre/make/tests/test_create_compile.py
+++ b/fre/make/tests/test_create_compile.py
@@ -68,11 +68,41 @@ def test_compile_creation():
                                          jobs = 4,
                                          parallel = 1,
                                          execute = False,
-                                         verbose = False)
+                                         verbose = False,
+                                         force_compile=False)
     # Check for creation of compile script
     assert Path(f"{OUT}/fremake_canopy/test/null_model_full/{plat}-{targ}/exec/compile.sh").exists()
 
-def test_compile_executable_failure():
+def test_compile_creation_force_compile(capfd):
+    """
+    Check for the re-creation of the compile script
+    if --force-compile is defined
+    """
+    # Set environment variable for use in ci.gnu platform
+    os.environ["TEST_BUILD_DIR"] = OUT
+
+    plat = PLATFORM[0]
+    targ = TARGET[0]
+    yamlfile_path = f"{TEST_DIR}/{NM_EXAMPLE}/{YAMLFILE}"
+
+    # Create the compile script
+    create_compile_script.compile_create(yamlfile = yamlfile_path,
+                                         platform = PLATFORM,
+                                         target = TARGET,
+                                         jobs = 4,
+                                         parallel = 1,
+                                         execute = False,
+                                         verbose = False,
+                                         force_compile=True)
+
+    #Capture output
+    out,err=capfd.readouterr()
+    if "Re-creating the compile script" in out:
+        assert Path(f"{OUT}/fremake_canopy/test/null_model_full/{plat}-{targ}/exec/compile.sh").exists()
+    else:
+       assert False
+
+def test_compile_executablefail_compilelog():
     """
     Check for the failure in execution of the compile script.
     Fails because it would need the makefile and checked out
@@ -92,14 +122,14 @@ def test_compile_executable_failure():
                                          jobs = 4,
                                          parallel = 1,
                                          execute = True,
-                                         verbose = False)
+                                         verbose = False,
+                                         force_compile=False)
 
-    # Check for creation of compile script, FMS directory,
+    # Check for creation of compile script,
     # log.compile file, the executable
     assert Path(f"{OUT}/fremake_canopy/test/null_model_full/{plat}-{targ}/exec/compile.sh").exists()
-    assert Path(f"{OUT}/fremake_canopy/test/null_model_full/{plat}-{targ}/exec/FMS").is_dir()
-    assert Path(f"{OUT}/fremake_canopy/test/null_model_full/{plat}-{targ}/exec/log.compile").exists()
     assert Path(f"{OUT}/fremake_canopy/test/null_model_full/{plat}-{targ}/exec/null_model_full.x").exists() == False
+    assert Path(f"{OUT}/fremake_canopy/test/null_model_full/{plat}-{targ}/exec/log.compile").exists()
 
 @pytest.mark.xfail(raises=ValueError)
 def test_bad_platform():
@@ -119,7 +149,8 @@ def test_bad_platform():
                                          jobs = 4,
                                          parallel = 1,
                                          execute = False,
-                                         verbose = False)
+                                         verbose = False,
+                                         force_compile=False)
 
 def test_bad_platform_compilelog():
     """
@@ -139,7 +170,8 @@ def test_bad_platform_compilelog():
                                              jobs = 4,
                                              parallel = 1,
                                              execute = False,
-                                             verbose = False)
+                                             verbose = False,
+                                             force_compile=False)
     except:
         assert Path(f"{OUT}/fremake_canopy/test/null_model_full/{BAD_PLATFORM}-{TARGET}/exec/log.compile")
 
@@ -161,7 +193,8 @@ def test_bad_target():
                                          jobs = 4,
                                          parallel = 1,
                                          execute = False,
-                                         verbose = False)
+                                         verbose = False,
+                                         force_compile=False)
 
 def test_bad_target_compilelog():
     """
@@ -181,7 +214,8 @@ def test_bad_target_compilelog():
                                              jobs = 4,
                                              parallel = 1,
                                              execute = False,
-                                             verbose = False)
+                                             verbose = False,
+                                             force_compile=False)
     except:
         assert Path(f"{OUT}/fremake_canopy/test/null_model_full/{BAD_PLATFORM}-{TARGET}/exec/log.compile")
 
@@ -201,7 +235,8 @@ def test_multi_target():
                                          jobs = 4,
                                          parallel = 1,
                                          execute = False,
-                                         verbose = False)
+                                         verbose = False,
+                                         force_compile=False)
 
     assert Path(f"{OUT}/fremake_canopy/test/null_model_full/{PLATFORM[0]}-{MULTI_TARGET[0]}/exec/compile.sh").exists()
     assert Path(f"{OUT}/fremake_canopy/test/null_model_full/{PLATFORM[0]}-{MULTI_TARGET[1]}/exec/compile.sh").exists()


### PR DESCRIPTION
## Describe your changes
This PR adds

- `force-compile`
- make it easier to edit scripts in between steps.

Previously, if steps were run to make scripts, then re-run, there would just be a print statement that the script existed already. However, if the user wanted to change something, let's say in the checkout script, then re-run to execute it, that functionality was not there. They would've had to edit something in their configuration and start over.

## Issue ticket number and link (if applicable)
#221 

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [x] I ran pylint and attempted to implement some of it's feedback
