### PR TITLE
Adds a link to the execution script in the container to the second stage of the dockerfile

### DIFF
--- a/fre/make/gfdlfremake/buildDocker.py
+++ b/fre/make/gfdlfremake/buildDocker.py
@@ -67,7 +67,9 @@ class container():
             self.secondstage = [f"FROM {self.stage2base} as final\n",
                                 f"COPY --from=builder  {self.src} {self.src}\n",
                                 f"COPY --from=builder {self.bld} {self.bld}\n",
-                                f"ENV PATH=$PATH:{self.bld}\n"]
+                                f"RUN mkdir -p /apps/bin \\ \n",
+                                f" && ln -sf "+self.bld+"/execrunscript.sh "+"/apps/bin/execrunscript.sh \n",
+                                f"ENV PATH=$PATH:{self.bld}:/apps/bin\n"]
     def writeDockerfileCheckout(self, cScriptName, cOnDisk):
         """
         Brief: writes to the checkout part of the Dockerfile and sets up the compile


### PR DESCRIPTION
## Describe your changes
This simply adds a link to execution script in the second stage build of the dockerfile.  This is needed only for compatibility with bronx frerun.  There is no new functionality.
## Issue ticket number and link (if applicable)
#371 

## Checklist before requesting a review

- [ ] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module
