### PR TITLE
Remove standard deviation feature from fre pp gen-time-averages

### DIFF
--- a/fre/app/freapp.py
+++ b/fre/app/freapp.py
@@ -103,17 +103,13 @@ def mask_atmos_plevel(infile, outfile, psfile):
               help = "Type of time average to generate. \n \
                      currently, fre-nctools and fre-python-tools pkg options\n \
                      do not support seasonal and monthly averaging.\n")
-@click.option("-s", "--stddev_type",
-              type = click.Choice(["samp","pop","samp_mean","pop_mean"]),
-              default = "samp",
-              help = "Compute standard deviations for time-averages as well")
-def gen_time_averages(inf, outf, pkg, var, unwgt, avg_type, stddev_type):
+def gen_time_averages(inf, outf, pkg, var, unwgt, avg_type):
     """
     generate time averages for specified set of netCDF files. 
     Example: generate-time-averages.py /path/to/your/files/
     """
     start_time = time.perf_counter()
-    generate(inf, outf, pkg, var, unwgt, avg_type, stddev_type)
+    generate(inf, outf, pkg, var, unwgt, avg_type)
     click.echo(f'Finished in total time {round(time.perf_counter() - start_time , 2)} second(s)')
 
 if __name__ == "__main__":

--- a/fre/app/generate_time_averages/cdoTimeAverager.py
+++ b/fre/app/generate_time_averages/cdoTimeAverager.py
@@ -43,39 +43,22 @@ class cdoTimeAverager(timeAverager):
                 print(f'wgts_sum={wgts_sum}')
 
         if self.avg_type == 'all':
-            if self.stddev_type is None:
-                print('time average over all time requested.')
-                if self.unwgt:
-                    _cdo.timmean(input=infile, output=outfile, returnCdf=True)
-                else:
-                    _cdo.divc( str(wgts_sum), input="-timsum -muldpm "+infile, output=outfile)
-
-                print('done averaging over all time.')
+            print('time average over all time requested.')
+            if self.unwgt:
+                _cdo.timmean(input=infile, output=outfile, returnCdf=True)
             else:
-                print('time standard-deviation (N-1) over all time requested.')
-                _cdo.timstd1(input=infile, output=outfile, returnCdf=True)
-                print('done computing standard-deviation over all time.')
+                _cdo.divc( str(wgts_sum), input="-timsum -muldpm "+infile, output=outfile)
+            print('done averaging over all time.')
 
         elif self.avg_type == 'seas':
-            if self.stddev_type is None:
-                print('seasonal time-averages requested.')
-                _cdo.yseasmean(input=infile, output=outfile, returnCdf=True)
-                print('done averaging over seasons.')
-            else:
-                print('seasonal time standard-deviation (N-1) requested.')
-                _cdo.yseasstd1(input=infile, output=outfile, returnCdf=True)
-                print('done averaging over seasons.')
+            print('seasonal time-averages requested.')
+            _cdo.yseasmean(input=infile, output=outfile, returnCdf=True)
+            print('done averaging over seasons.')
 
         elif self.avg_type == 'month':
-
-            if self.stddev_type is None:
-                print('monthly time-averages requested.')
-                _cdo.ymonmean(input=infile, output=outfile, returnCdf=True)
-                print('done averaging over months.')
-            else:
-                print('monthly time standard-deviation (N-1) requested.')
-                _cdo.ymonstd1(input=infile, output=outfile, returnCdf=True)
-                print('done averaging over months.')
+            print('monthly time-averages requested.')
+            _cdo.ymonmean(input=infile, output=outfile, returnCdf=True)
+            print('done averaging over months.')
 
         else:
             print(f'problem: unknown avg_type={self.avg_type}')

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -21,9 +21,6 @@ class frenctoolsTimeAverager(timeAverager):
         if self.unwgt:
             print('WARNING: unwgt=True unsupported by frenctoolsAverager. ignoring!!!')
 
-        if self.stddev_type is not None:
-            print('WARNING: stddev_type arg unsupported by frenctoolsTimeAverager. ignoring!!!')
-
         if self.var is not None:
             print(f'WARNING: variable specification (var={self.var})' + \
                    ' not currently supported for frenctols time averaging. ignoring!')

--- a/fre/app/generate_time_averages/frepytoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frepytoolsTimeAverager.py
@@ -84,9 +84,6 @@ class frepytoolsTimeAverager(timeAverager):
         num_lon_bnds=fin_dims['lon'].size
         print(f'num_lon_bnds={num_lon_bnds}')
         avgvals=numpy.zeros((1,num_lat_bnds,num_lon_bnds),dtype=float)
-        if self.stddev_type is not None:
-            print('computing std. deviations')
-            stddevs=numpy.zeros((1,num_lat_bnds,num_lon_bnds),dtype=float)
 
         # this loop behavior 100% should be re-factored into generator functions.
         # they should be slightly faster, and much more readable. (TODO)
@@ -105,12 +102,6 @@ class frepytoolsTimeAverager(timeAverager):
                     avgvals[0][lat][lon]=sum( (tim_val_array[tim] * wgts[tim] )
                                               for tim in range(num_time_bnds) ) / wgts_sum
 
-                    if self.stddev_type is not None: # implement stddeviation types TO DO
-                        stddevs[0][lat][lon]=math.sqrt(
-                                             sum( wgts[tim] *
-                                                  (tim_val_array[tim]-avgvals[0][lat][lon]) ** 2
-                                                  for tim in range(num_time_bnds) )
-                                              / wgts_sum )
                     del tim_val_array
                 del lon_val_array
         else: #unweighted case
@@ -124,14 +115,6 @@ class frepytoolsTimeAverager(timeAverager):
                         tim_val_array[tim] for tim in range(num_time_bnds)
                                ) / num_time_bnds
 
-                    if self.stddev_type is not None:
-
-                        stddevs[0][lat][lon]=math.sqrt(
-                                                      sum(
-                                                  (tim_val_array[tim]-avgvals[0][lat][lon]) ** 2
-                                                          for tim in range(num_time_bnds)
-                                                      ) / ( (num_time_bnds - 1. ) )
-                                                           )
                     del tim_val_array
                 del lon_val_array
 
@@ -201,12 +184,6 @@ class frepytoolsTimeAverager(timeAverager):
 
 
         nc_fout.variables[targ_var][:]=avgvals
-        if self.stddev_type is not None:
-            stddev_varname=targ_var+'_'+self.stddev_type+'_stddev'
-            nc_fout.createVariable(
-                stddev_varname, nc_fin[targ_var].dtype, nc_fin[targ_var].dimensions )
-            nc_fout.variables[stddev_varname].setncatts(nc_fin[targ_var].__dict__)
-            nc_fout.variables[stddev_varname][:]=stddevs
         print('---------- DONE writing output variables. ---------')
         ##
 

--- a/fre/app/generate_time_averages/generate_time_averages.py
+++ b/fre/app/generate_time_averages/generate_time_averages.py
@@ -4,7 +4,7 @@ fre_logger = logging.getLogger(__name__)
 
 def generate_time_average(infile = None, outfile = None,
                           pkg = None, var = None, unwgt = False,
-                          avg_type = None, stddev_type = None):
+                          avg_type = None):
     ''' steering function to various averaging functions above'''
     if __debug__:
         fre_logger.info(locals()) #input argument details
@@ -16,19 +16,19 @@ def generate_time_average(infile = None, outfile = None,
         from .cdoTimeAverager import cdoTimeAverager
         myavger=cdoTimeAverager(pkg = pkg, var=var,
                                 unwgt = unwgt,
-                                avg_type = avg_type, stddev_type = stddev_type)
+                                avg_type = avg_type)
 
     elif pkg == 'fre-nctools'    :
         from .frenctoolsTimeAverager import frenctoolsTimeAverager
         myavger=frenctoolsTimeAverager(pkg = pkg, var=var,
                                        unwgt = unwgt ,
-                                       avg_type = avg_type, stddev_type = stddev_type)
+                                       avg_type = avg_type)
 
     elif pkg == 'fre-python-tools':
         from .frepytoolsTimeAverager import frepytoolsTimeAverager
         myavger=frepytoolsTimeAverager(pkg = pkg, var=var,
                                        unwgt = unwgt,
-                                       avg_type = avg_type, stddev_type = stddev_type)
+                                       avg_type = avg_type)
 
     else :
         fre_logger.info('requested package unknown. exit.')
@@ -45,12 +45,12 @@ def generate_time_average(infile = None, outfile = None,
 
 def generate(inf = None, outf = None,
              pkg = None, var = None, unwgt = False,
-             avg_type = None, stddev_type = None):
+             avg_type = None):
     ''' click entrypoint to time averaging routine '''
     exitstatus=generate_time_average( inf, outf,
                                       pkg, var,
                                       unwgt,
-                                      avg_type, stddev_type)
+                                      avg_type)
     if exitstatus!=0:
         fre_logger.info(f'WARNING: exitstatus={exitstatus} != 0. Something exited poorly!')
     else:
@@ -59,5 +59,5 @@ def generate(inf = None, outf = None,
 if __name__ == '__main__':
     import time
     start_time=time.perf_counter()
-    generate(inf, outf, pkg, var, unwgt, avg_type, stddev_type)
+    generate(inf, outf, pkg, var, unwgt, avg_type)
     fre_logger.info(f'Finished in total time {round(time.perf_counter() - start_time , 2)} second(s)')

--- a/fre/app/generate_time_averages/tests/test_generate_time_averages.py
+++ b/fre/app/generate_time_averages/tests/test_generate_time_averages.py
@@ -2,8 +2,7 @@
 import pathlib as pl
 import pytest
 
-def run_avgtype_pkg_calculations(infile=None,outfile=None, pkg=None, avg_type=None, unwgt=None,
-                                 stddev_type=None):
+def run_avgtype_pkg_calculations(infile=None,outfile=None, pkg=None, avg_type=None, unwgt=None):
     ''' test-harness function, called by other test functions. '''
     assert all( [infile is not None, outfile is not None,
                  pkg is not None, avg_type is not None,
@@ -14,7 +13,7 @@ def run_avgtype_pkg_calculations(infile=None,outfile=None, pkg=None, avg_type=No
     from fre.app.generate_time_averages import generate_time_averages as gtas
     gtas.generate_time_average(infile = infile, outfile = outfile,
                                pkg = pkg, unwgt = unwgt,
-                               avg_type = avg_type, stddev_type = stddev_type)
+                               avg_type = avg_type)
     return pl.Path(outfile).exists()
 
 ### preamble tests. if these fail, none of the others will succeed. -----------------
@@ -65,36 +64,7 @@ def test_cdo_time_avgs():
         pkg='cdo',avg_type='all',unwgt=False )
 
 
-### cdo stddevs, unweighted, all/seasonal/monthly ------------------------
-def test_monthly_cdo_time_unwgt_stddevs():
-    ''' generates a monthly time averaged file using cdo '''
-    assert run_avgtype_pkg_calculations(
-        infile  = (time_avg_file_dir+test_file_name),
-        outfile = (time_avg_file_dir+'ymonstddev1_unwgt_'+test_file_name),
-        pkg='cdo',avg_type='month',stddev_type='samp', unwgt=True )
-
-def test_seasonal_cdo_time_unwgt_stddevs():
-    ''' generates a seasonal time averaged file using cdo '''
-    assert run_avgtype_pkg_calculations(
-        infile  = (time_avg_file_dir+test_file_name),
-        outfile = (time_avg_file_dir+'yseasstddev1_unwgt_'+test_file_name),
-        pkg='cdo',avg_type='seas',stddev_type='samp',unwgt=True )
-
-def test_cdo_time_unwgt_stddevs():
-    ''' generates a time averaged file using cdo '''
-    assert run_avgtype_pkg_calculations(
-        infile  = (time_avg_file_dir+test_file_name),
-        outfile = (time_avg_file_dir+'yseasmean_unwgt_'+test_file_name),
-        pkg='cdo',avg_type='all',stddev_type='samp', unwgt=True )
-
-
-#### cdo stddevs, weighted, all/seasonal/monthly -----------------------
-## (TODO) WRITE THESE VERSIONS FOR CDOTIMEAVERAGER CLASS THEN MAKE THESE TESTS
-#def test_monthly_cdo_time_stddevs():
-#def test_seasonal_cdo_time_stddevs():
-#def test_cdo_time_stddevs():
-
-## frepythontools avgs+stddevs, weighted+unweighted, all ------------------------
+## frepythontools avgs, weighted+unweighted, all ------------------------
 def test_fre_cli_time_avgs():
     ''' generates a time averaged file using fre_cli's version '''
     ''' weighted average, no std deviation '''
@@ -111,32 +81,13 @@ def test_fre_cli_time_unwgt_avgs():
         outfile = (time_avg_file_dir+'frepytools_unwgt_timavg_'+test_file_name),
         pkg='fre-python-tools',avg_type='all', unwgt=True )
 
-def test_fre_cli_time_avgs_stddevs():
-    ''' generates a time averaged file using fre_cli's version '''
-    ''' weighted average, no std deviation '''
-    assert run_avgtype_pkg_calculations(
-        infile  = (time_avg_file_dir+test_file_name),
-        outfile = (time_avg_file_dir+'frepytools_stddev_'+test_file_name),
-        pkg='fre-python-tools',avg_type='all', stddev_type='samp', unwgt=False )
-
-def test_fre_cli_time_unwgt_avgs_stddevs():
-    ''' generates a time averaged file using fre_cli's version '''
-    ''' weighted average, no std deviation '''
-    assert run_avgtype_pkg_calculations(
-        infile  = (time_avg_file_dir+test_file_name),
-        outfile = (time_avg_file_dir+'frepytools_unwgt_stddev_'+test_file_name),
-        pkg='fre-python-tools',avg_type='all', stddev_type='samp', unwgt=True )
 
 ## (TODO) WRITE THESE VERSIONS FOR FREPYTOOLSTIMEAVERAGER CLASS THEN MAKE THESE TESTS
 #def test_monthly_fre_cli_time_avgs():
 #def test_monthly_fre_cli_time_unwgt_avgs():
-#def test_monthly_fre_cli_time_avgs_stddevs():
-#def test_monthly_fre_cli_time_unwgt_avgs_stddevs():
 #
 #def test_seasonal_fre_cli_time_avgs():
 #def test_seasonal_fre_cli_time_unwgt_avgs():
-#def test_seasonal_fre_cli_time_avgs_stddevs():
-#def test_seasonal_fre_cli_time_unwgt_avgs_stddevs(:)
 
 
 

--- a/fre/app/generate_time_averages/timeAverager.py
+++ b/fre/app/generate_time_averages/timeAverager.py
@@ -9,7 +9,6 @@ class timeAverager:
     var: str
     unwgt: bool
     avg_type: str
-    stddev_type: str
 
     def __init__(self):
         ''' init method 1, no inputs given '''
@@ -17,24 +16,21 @@ class timeAverager:
         self.var = None
         self.unwgt = False
         self.avg_type = "all" #see argparser for options
-        self.stddev_type = None #see argparser for options
 
     def __init__(self, pkg, var, unwgt,
-                 avg_type, stddev_type):
+                 avg_type):
         ''' init method 2, all inputs specified '''
         self.pkg = pkg
         self.var = var
         self.unwgt = unwgt
         self.avg_type = avg_type
-        self.stddev_type = stddev_type
 
     def __repr__(self):
         ''' return text representation of object '''
         return f'{type(self).__name__}( pkg={self.pkg}, \
                                unwgt={self.unwgt}, \
                                var={self.var}, \
-                               avg_type={self.avg_type}, \
-                               stddev_type={self.stddev_type})'
+                               avg_type={self.avg_type})'
 
     def var_has_time_units(self, an_nc_var=None):
         ''' checks if variable's units are of time '''


### PR DESCRIPTION
Timeaveraging itself is complicated enough!
Standard deviation calculation could be its own tool in the future.

## Describe your changes

## Issue ticket number and link (if applicable)

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module
