### PR TITLE
Require python 3.10 and remove cylc-uiserver as a dependency

### DIFF
--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -45,7 +45,7 @@ jobs:
           export PATH="$path_save"
 
           # install genbadge to make badge from coverage/test stats
-          pip install genbadge
+          pip install defusedxml genbadge
 
           # genbadge coverage
           genbadge coverage -v -i coverage.xml -o docs/cov_badge.svg

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - noaa-gfdl
 dependencies:
-  - python>=3.10
+  - python==3.10
   - pip
   - click
   - pyyaml

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - noaa-gfdl
 dependencies:
-  - python>=3.9.0
+  - python>=3.10
   - pip
   - click
   - pyyaml
@@ -17,7 +17,6 @@ dependencies:
   - conda-forge::cylc-rose
   - conda-forge::metomi-rose
   - conda-forge::cmor>=3.9.0
-  - conda-forge::cylc-uiserver
   - conda-forge::pytest
   - conda-forge::pytest-cov
   - conda-forge::python-cdo

--- a/meta.yaml
+++ b/meta.yaml
@@ -21,10 +21,10 @@ channels:
 
 requirements:
   host:
-    - python>=3.9
+    - python>=3.10
     - pip
   run:
-    - python>=3.9
+    - python>=3.10
     - pip
     - click
     - pyyaml
@@ -38,7 +38,6 @@ requirements:
     - conda-forge::cylc-rose
     - conda-forge::metomi-rose
     - conda-forge::cmor>=3.9.0
-    - conda-forge::cylc-uiserver
     - conda-forge::pytest
     - conda-forge::pytest-cov
     - conda-forge::python-cdo

--- a/meta.yaml
+++ b/meta.yaml
@@ -21,10 +21,10 @@ channels:
 
 requirements:
   host:
-    - python>=3.10
+    - python==3.10
     - pip
   run:
-    - python>=3.10
+    - python==3.10
     - pip
     - click
     - pyyaml


### PR DESCRIPTION
## Describe your changes
Python 3.9 is too old (not receiving security updates) and probably causes fre analysis install issues.

Hand testing showed cylc-uiserver was causing the solver to always use 3.9.

## Issue ticket number and link (if applicable)

## Checklist before requesting a review

- [ ] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module
