### PR TITLE
Combine yamls fix

### DIFF
--- a/fre/yamltools/pp_info_parser.py
+++ b/fre/yamltools/pp_info_parser.py
@@ -114,7 +114,7 @@ class InitPPYaml():
         # If only 1 pp yaml defined, combine with model yaml
         if ey_path is not None and len(ey_path) == 1:
             #expyaml_path = os.path.join(mainyaml_dir, i)
-            with open(ey_path,'r') as eyp:
+            with open(ey_path[0],'r') as eyp:
                 exp_content = eyp.read()
 
             exp_info = yaml_content + exp_content
@@ -140,13 +140,13 @@ class InitPPYaml():
         """
         # Experiment Check
         (ey_path,ay_path) = experiment_check(self.mainyaml_dir,self.name,loaded_yaml)
-
+        
         analysis_yamls = []
         ## COMBINE EXPERIMENT YAML INFO
         # If only 1 pp yaml defined, combine with model yaml
         if ay_path is not None and len(ay_path) == 1:
             #expyaml_path = os.path.join(mainyaml_dir, i)
-            with open(ay_path,'r') as ayp:
+            with open(ay_path[0],'r') as ayp:
                 analysis_content = ayp.read()
 
             analysis_info = yaml_content + analysis_content

--- a/fre/yamltools/pp_info_parser.py
+++ b/fre/yamltools/pp_info_parser.py
@@ -140,12 +140,11 @@ class InitPPYaml():
         """
         # Experiment Check
         (ey_path,ay_path) = experiment_check(self.mainyaml_dir,self.name,loaded_yaml)
-        
+ 
         analysis_yamls = []
         ## COMBINE EXPERIMENT YAML INFO
-        # If only 1 pp yaml defined, combine with model yaml
+        # If only 1 analysis yaml defined, combine with model yaml
         if ay_path is not None and len(ay_path) == 1:
-            #expyaml_path = os.path.join(mainyaml_dir, i)
             with open(ay_path[0],'r') as ayp:
                 analysis_content = ayp.read()
 


### PR DESCRIPTION
## Describe your changes
If there was only 1 experiment or analysis yaml listed, there would be a problem with combining yaml information. This was because the experiment and analysis yaml paths were passed in a list but then they were not looped over. 

I just added indexing the first element in the list, if there was only 1 experiment or analysis yaml listed. 

## Issue ticket number and link (if applicable)

## Checklist before requesting a review

- [x] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module
