### PR TITLE
Monthly climatology.391

### DIFF
--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -5,6 +5,7 @@ from netCDF4 import Dataset, num2date
 import calendar
 from cdo import Cdo
 import logging
+import subprocess
 
 cdo = Cdo()
 fre_logger = logging.getLogger(__name__)
@@ -73,10 +74,10 @@ class frenctoolsTimeAverager(timeAverager):
                         stdout=PIPE, stderr=PIPE, shell=False) as subp:
                     output=subp.communicate()[0]
                             
-                    if os.path.exists("timavg.csh"):
-                        continue
-                    else:
-                        fre_logger.error("No timavg.csh file found")
+                    try:
+                        subprocess.run(['which timavg.csh'], shell = True)
+                    except:
+                        fre_logger.error('did not find timavg.csh')
                         
                     if subp.returncode < 0:
                         fre_logger.error('error')

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -20,7 +20,6 @@ class frenctoolsTimeAverager(timeAverager):
 
         exitstatus=1
         if self.avg_type not in ['month','all']:
-            print('correct location')
             print(f'ERROR: avg_type={self.avg_type} not supported by this class at this time.')
             return exitstatus
 
@@ -70,12 +69,11 @@ class frenctoolsTimeAverager(timeAverager):
                 with Popen(timavgcsh_command,
                         stdout=PIPE, stderr=PIPE, shell=False) as subp:
                     output=subp.communicate()[0]
-                    print(f'output={output}')
 
                     if subp.returncode < 0:
                         print('error')
                     else:
-                        print(f'{nc_monthly_file} climitology successfully ran')
+                        print(f'{nc_monthly_file} climatology successfully ran')
                         exitstatus=0
                 #Delete files after being used to generate output files
             for month_index in month_indices:  

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -1,6 +1,7 @@
 ''' class for utilizing timavg.csh (aka script to TAVG fortran exe) in frenc-tools '''
 from .timeAverager import timeAverager
 import os 
+from netCDF4 import Dataset
 
 class frenctoolsTimeAverager(timeAverager):
     '''

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -81,7 +81,7 @@ class frenctoolsTimeAverager(timeAverager):
                     output=subp.communicate()[0]
                             
 
-                    if subp.returncode < 0:
+                    if subp.returncode > 0:
                         raise ValueError('error: timavgcsh command not properly executed')
                     else:
                         fre_logger.info('%s climatology successfully ran',nc_monthly_file)
@@ -100,7 +100,7 @@ class frenctoolsTimeAverager(timeAverager):
             output=subp.communicate()[0]
             fre_logger.info('output= %s',output)
 
-            if subp.returncode < 0:
+            if subp.returncode > 0:
                 raise ValueError('error: timavgcsh command not properly executed')
             else:
                 fre_logger.info('climatology successfully ran')

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -76,12 +76,12 @@ class frenctoolsTimeAverager(timeAverager):
                     if pathlib.Path.exists("timavg.csh"):
                         continue
                     else:
-                        print("No timavg.csh file found")
+                        fre_logger.error("No timavg.csh file found")
                         
                     if subp.returncode < 0:
-                        print('error')
+                        fre_logger.error('error')
                     else:
-                        print(f'{nc_monthly_file} climatology successfully ran')
+                        fre_logger.info('%s climatology successfully ran',nc_monthly_file)
                         exitstatus=0
                         
                 #Delete files after being used to generate output files
@@ -100,12 +100,12 @@ class frenctoolsTimeAverager(timeAverager):
         with Popen(timavgcsh_command,
                    stdout=PIPE, stderr=PIPE, shell=False) as subp:
             output=subp.communicate()[0]
-            print(f'output={output}')
+            fre_logger.info('output= %s',output)
 
             if subp.returncode < 0:
-                print('error')
+                fre_logger.error('error')
             else:
-                print('success')
+                fre_logger.info('success')
                 exitstatus=0
 
         return exitstatus

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -42,7 +42,7 @@ class frenctoolsTimeAverager(timeAverager):
             fre_logger.warning('No output filename given, setting outfile= %s', outfile)
         
         #check for existence of timavg.csh. If not found, issue might be that user is not in env with frenctools.
-        if shutil.which('timavg.csh') == None:
+        if shutil.which('timavg.csh') is None:
             raise fre_logger.error('did not find timavg.csh')
             
         from subprocess import Popen, PIPE

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -44,7 +44,7 @@ class frenctoolsTimeAverager(timeAverager):
         try:
             subprocess.run(['which timavg.csh'], shell = True)
         except:
-            fre_logger.error('did not find timavg.csh')
+            raise fre_logger.error('did not find timavg.csh')
             
         from subprocess import Popen, PIPE
 ########################################################################################
@@ -81,7 +81,7 @@ class frenctoolsTimeAverager(timeAverager):
 
                         
                     if subp.returncode < 0:
-                        fre_logger.error('error')
+                        fre_logger.error('error: timavgcsh command not properly executed')
                     else:
                         fre_logger.info('%s climatology successfully ran',nc_monthly_file)
                         exitstatus=0
@@ -104,9 +104,9 @@ class frenctoolsTimeAverager(timeAverager):
             fre_logger.info('output= %s',output)
 
             if subp.returncode < 0:
-                fre_logger.error('error')
+                fre_logger.error('error: timavgcsh command not properly executed')
             else:
-                fre_logger.info('success')
+                fre_logger.info('climatology successfully ran')
                 exitstatus=0
 
         return exitstatus

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -55,7 +55,7 @@ class frenctoolsTimeAverager(timeAverager):
 
             #Dictionary to store output filenames by month
             nc_month_file_paths = {month: os.path.join(monthly_nc_dir, f"{month}_all_years.nc") for month in month_names}
-            month_output_file_paths = {month: os.path.join(output_dir, f"{month}_{outfile}") for month in month_names}
+            month_output_file_paths = {month: os.path.join(output_dir, f"{outfile}_.{number}.nc") for number in month_indices}
 
             #Loop through each month and select the corresponding data
             for month_index in month_indices:

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -43,10 +43,9 @@ class frenctoolsTimeAverager(timeAverager):
             output_dir = f"monthly_outputs"
             os.makedirs(output_dir, exist_ok=True)
             # Extract unique months from the infile 
-            with Dataset(infile) as ds:
-                times = ds.variables['time'][:]
-                dates = num2date(times, units=ds.variables['time'].units)
-            unique_month_names = sorted(set((date.month, date.year) for date in dates))
+
+            unique_month_names = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+
             # Dictionary to store output filenames by month
             month_file_names = {month: os.path.join(output_dir, f"{month:02d}_all_years.nc") for month, _ in unique_month_names}
 

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -24,7 +24,7 @@ class frenctoolsTimeAverager(timeAverager):
 
         exitstatus=1
         if self.avg_type not in ['month','all']:
-            fre_logger.error('avg_type= %s not supported by this class at this time.', self.avg_type)
+            raise FileError(f'avg_type= {self.avg_type} not supported by this class at this time.')
 
         if self.unwgt:
             fre_logger.warning('unwgt=True unsupported by frenctoolsAverager. Ignoring!!!')

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -54,7 +54,7 @@ class frenctoolsTimeAverager(timeAverager):
             month_names = [calendar.month_name[i] for i in month_indices]
 
             #Dictionary to store output filenames by month
-            nc_month_file_paths = {month_index: os.path.join(monthly_nc_dir, f"{month}_all_years.nc") for month_index in month_indices}
+            nc_month_file_paths = {month_index: os.path.join(monthly_nc_dir, f"all_years.{month_index}.nc") for month_index in month_indices}
             month_output_file_paths = {month_index: os.path.join(output_dir, f"{outfile}_.{number}.nc") for month_index in month_indices}
 
             #Loop through each month and select the corresponding data

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -24,7 +24,7 @@ class frenctoolsTimeAverager(timeAverager):
 
         exitstatus=1
         if self.avg_type not in ['month','all']:
-            raise fre_logger.error('avg_type= %s not supported by this class at this time.', self.avg_type)
+            fre_logger.error('avg_type= %s not supported by this class at this time.', self.avg_type)
 
         if self.unwgt:
             fre_logger.warning('unwgt=True unsupported by frenctoolsAverager. Ignoring!!!')
@@ -35,7 +35,6 @@ class frenctoolsTimeAverager(timeAverager):
 
         if infile is None:
             fre_logger.error('Need an input file, specify a value for the infile argument')
-            raise FileError()
             
         if outfile is None:
             outfile='frenctoolsTimeAverage_'+infile
@@ -44,7 +43,6 @@ class frenctoolsTimeAverager(timeAverager):
         #check for existence of timavg.csh. If not found, issue might be that user is not in env with frenctools.
         if shutil.which('timavg.csh') is None:
             fre_logger.error('did not find timavg.csh')
-            raise FileError()
             
         from subprocess import Popen, PIPE
 
@@ -63,9 +61,10 @@ class frenctoolsTimeAverager(timeAverager):
             nc_month_file_paths = {month_index: os.path.join(monthly_nc_dir, f"all_years.{month_index}.nc") for month_index in month_indices}
             month_output_file_paths = {month_index: os.path.join(output_dir, f"{outfile}_.{month_index}.nc") for month_index in month_indices}
 
+            cdo = Cdo()
             #Loop through each month and select the corresponding data
             for month_index in month_indices:
-                cdo = Cdo()
+                
 
                 month_name = month_names[month_index - 1]
                 nc_monthly_file = nc_month_file_paths[month_index]
@@ -84,7 +83,6 @@ class frenctoolsTimeAverager(timeAverager):
 
                     if subp.returncode < 0:
                         fre_logger.error('error: timavgcsh command not properly executed')
-                        raise FileError()
                     else:
                         fre_logger.info('%s climatology successfully ran',nc_monthly_file)
                         exitstatus=0

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -34,7 +34,7 @@ class frenctoolsTimeAverager(timeAverager):
                    ' not currently supported for frenctols time averaging. ignoring!', self.var)
 
         if infile is None:
-            fre_logger.error('Need an input file, specify a value for the infile argument')
+            raise ValueError('Need an input file, specify a value for the infile argument')
             
         if outfile is None:
             outfile='frenctoolsTimeAverage_'+infile
@@ -42,7 +42,7 @@ class frenctoolsTimeAverager(timeAverager):
         
         #check for existence of timavg.csh. If not found, issue might be that user is not in env with frenctools.
         if shutil.which('timavg.csh') is None:
-            fre_logger.error('did not find timavg.csh')
+            raise ValueError'did not find timavg.csh')
             
         from subprocess import Popen, PIPE
 
@@ -82,7 +82,7 @@ class frenctoolsTimeAverager(timeAverager):
                             
 
                     if subp.returncode < 0:
-                        fre_logger.error('error: timavgcsh command not properly executed')
+                        raise ValueError('error: timavgcsh command not properly executed')
                     else:
                         fre_logger.info('%s climatology successfully ran',nc_monthly_file)
                         exitstatus=0
@@ -101,7 +101,7 @@ class frenctoolsTimeAverager(timeAverager):
             fre_logger.info('output= %s',output)
 
             if subp.returncode < 0:
-                fre_logger.error('error: timavgcsh command not properly executed')
+                raise ValueError('error: timavgcsh command not properly executed')
             else:
                 fre_logger.info('climatology successfully ran')
                 exitstatus=0

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -52,25 +52,38 @@ class frenctoolsTimeAverager(timeAverager):
             month_names = [calendar.month_name[i] for i in month_indices]
 
             # Dictionary to store output filenames by month
-            month_file_paths = {month: os.path.join(output_dir, f"{month}_all_years.nc") for month in month_names}
+            nc_month_file_paths = {month: os.path.join(monthly_nc_dir, f"{month}_all_years.nc") for month in month_names}
+            month_output_file_paths = {month: os.path.join(output_dir, f"{month}_{outfile}") for month in month_names}
 
             # Loop through each month and select the corresponding data
         # Loop through each month and select the corresponding data
             for month_index in month_indices:
                 month_name = month_names[month_index - 1]
-                nc_monthly_file = month_file_paths[month_name]
+                nc_monthly_file = nc_month_file_paths[month_name]
 
                 # Select data for the given month
                 cdo.select(f"month={month_index}", input=infile, output=nc_monthly_file)
 
                 #run timavg command for newly created file
-                month_output_file_name = outfile
+                month_output_file = month_output_file_paths[month_name]
+                timavgcsh_command=['timavg.csh', '-mb','-o', month_output_file, nc_monthly_file]
+                exitstatus=1
+                with Popen(timavgcsh_command,
+                        stdout=PIPE, stderr=PIPE, shell=False) as subp:
+                    output=subp.communicate()[0]
+                    print(f'output={output}')
+
+                    if subp.returncode < 0:
+                        print('error')
+                    else:
+                        print(f'{nc_monthly_file} climitology successfully ran')
+                        exitstatus=0
                 #Delete files after being used to generate output files
-            #for month_index in month_indices:  
-             #   month_name = month_names[month_index - 1]
-              #  nc_monthly_file = month_file_paths[month_name]              
-               # os.remove(nc_monthly_file)
-           # os.rmdir('monthly_outputs')    
+            for month_index in month_indices:  
+                month_name = month_names[month_index - 1]
+                nc_monthly_file = nc_month_file_paths[month_name]              
+                os.remove(nc_monthly_file)
+            os.rmdir('monthly_nc_files')    
 ########################################################################################
 
             

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -69,12 +69,18 @@ class frenctoolsTimeAverager(timeAverager):
                 with Popen(timavgcsh_command,
                         stdout=PIPE, stderr=PIPE, shell=False) as subp:
                     output=subp.communicate()[0]
-
+                            
+                    if pathlib.Path.exists("timavg.csh"):
+                        continue
+                    else:
+                        print("No timavg.csh file found")
+                        
                     if subp.returncode < 0:
                         print('error')
                     else:
                         print(f'{nc_monthly_file} climatology successfully ran')
                         exitstatus=0
+                        
                 #Delete files after being used to generate output files
             for month_index in month_indices:  
                 month_name = month_names[month_index - 1]

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -55,7 +55,7 @@ class frenctoolsTimeAverager(timeAverager):
 
             #Dictionary to store output filenames by month
             nc_month_file_paths = {month_index: os.path.join(monthly_nc_dir, f"all_years.{month_index}.nc") for month_index in month_indices}
-            month_output_file_paths = {month_index: os.path.join(output_dir, f"{outfile}_.{number}.nc") for month_index in month_indices}
+            month_output_file_paths = {month_index: os.path.join(output_dir, f"{outfile}_.{month_index}.nc") for month_index in month_indices}
 
             #Loop through each month and select the corresponding data
             for month_index in month_indices:

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -1,7 +1,8 @@
 ''' class for utilizing timavg.csh (aka script to TAVG fortran exe) in frenc-tools '''
 from .timeAverager import timeAverager
 import os 
-from netCDF4 import Dataset
+from netCDF4 import Dataset, num2date
+import calendar
 from cdo import Cdo
 cdo = Cdo()
 
@@ -45,18 +46,21 @@ class frenctoolsTimeAverager(timeAverager):
             output_dir = f"monthly_outputs"
             os.makedirs(output_dir, exist_ok=True)
             # Extract unique months from the infile 
-
-            unique_month_names = sorted(["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"])
+            month_indices = list(range(1, 13))
+            month_names = [calendar.month_name[i] for i in month_indices]
 
             # Dictionary to store output filenames by month
             month_file_names = {month: os.path.join(output_dir, f"{month}_all_years.nc") for month in unique_month_names}
 
             # Loop through each month and select the corresponding data
-            for month in unique_month_names:
+        # Loop through each month and select the corresponding data
+            for month_index in month_indices:
+                month_name = month_names[month_index - 1]
+                output_file = month_file_paths[month_name]
+
                 # Select data for the given month
-                cdo.select(f"month={month}", input=infile, output=month_file_names[month])
-            
-                print(f"Created file for month {month}: {month_file_names[month]}")
+                cdo.select(f"month={month_index}", input=infile, output=output_file)
+
 
                 #Delete files after being used to generate output files
                 for file in month_file_names:

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -4,7 +4,10 @@ import os
 from netCDF4 import Dataset, num2date
 import calendar
 from cdo import Cdo
+import logging
+
 cdo = Cdo()
+fre_logger = logging.getLogger(__name__)
 
 class frenctoolsTimeAverager(timeAverager):
     '''
@@ -16,27 +19,27 @@ class frenctoolsTimeAverager(timeAverager):
         ''' use fre-nctool's CLI timavg.csh with subprocess call '''
         assert self.pkg=="fre-nctools"
         if __debug__:
-            print(locals()) #input argument details
+            fre_logger.debug(locals()) #input argument details
 
         exitstatus=1
         if self.avg_type not in ['month','all']:
-            print(f'ERROR: avg_type={self.avg_type} not supported by this class at this time.')
+            fre_logger.error('avg_type= %s not supported by this class at this time.', self.avg_type)
             return exitstatus
 
         if self.unwgt:
-            print('WARNING: unwgt=True unsupported by frenctoolsAverager. ignoring!!!')
+            fre_logger.warning('unwgt=True unsupported by frenctoolsAverager. Ignoring!!!')
 
         if self.var is not None:
-            print(f'WARNING: variable specification (var={self.var})' + \
-                   ' not currently supported for frenctols time averaging. ignoring!')
+            fre_logger.warning('Variable specification (var= %s)' + \
+                   ' not currently supported for frenctols time averaging. ignoring!', self.var)
 
         if infile is None:
-            print('ERROR: I need an input file, specify a value for the infile argument')
+            fre_logger.error('Need an input file, specify a value for the infile argument')
             return exitstatus
 
         if outfile is None:
             outfile='frenctoolsTimeAverage_'+infile
-            print(f'WARNING: no output filename given, setting outfile={outfile}')
+            fre_logger.warning('No output filename given, setting outfile= %s', outfile)
 
         from subprocess import Popen, PIPE
 ########################################################################################

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -42,14 +42,16 @@ class frenctoolsTimeAverager(timeAverager):
         if outfile is None:
             outfile='frenctoolsTimeAverage_'+infile
             fre_logger.warning('No output filename given, setting outfile= %s', outfile)
-            
+        
+        #check for existence of timavg.csh. If not found, issue might be that user is not in env with frenctools.
         try:
             shutil.which('timavg.csh')
         except:
             raise fre_logger.error('did not find timavg.csh')
             
         from subprocess import Popen, PIPE
-########################################################################################
+
+        
         #Recursive call if month is selcted for climatology. by Avery Kiihne
         if self.avg_type == 'month':
             monthly_nc_dir = f"monthly_nc_files"    #Folder that new monthly input files are put 
@@ -57,7 +59,7 @@ class frenctoolsTimeAverager(timeAverager):
             os.makedirs(monthly_nc_dir, exist_ok=True)   #create directory if it does not exist
             os.makedirs(output_dir, exist_ok=True)
             #Extract unique months from the infile 
-            month_indices = list(range(1, 13))
+            month_indices = list(range(1, 13))   #serves to track month index and as part of the outfile name
             month_names = [calendar.month_name[i] for i in month_indices]
 
             #Dictionary to store output filenames by month
@@ -81,7 +83,6 @@ class frenctoolsTimeAverager(timeAverager):
                     output=subp.communicate()[0]
                             
 
-                        
                     if subp.returncode < 0:
                         fre_logger.error('error: timavgcsh command not properly executed')
                     else:
@@ -96,7 +97,6 @@ class frenctoolsTimeAverager(timeAverager):
 
         if self.avg_type == 'month':   #End here if month variable used
             return exitstatus
-########################################################################################
         
         timavgcsh_command=['timavg.csh', '-mb','-o', outfile, infile]
         exitstatus=1

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -43,7 +43,9 @@ class frenctoolsTimeAverager(timeAverager):
 ########################################################################################
         #recursive call if month is selcted for climatology. by Avery Kiihne
         if self.avg_type == 'month':
-            output_dir = f"monthly_outputs"
+            monthly_nc_dir = f"monthly_nc_files"
+            output_dir = f"monthly_output_files"
+            os.makedirs(monthly_nc_dir, exist_ok=True)
             os.makedirs(output_dir, exist_ok=True)
             # Extract unique months from the infile 
             month_indices = list(range(1, 13))
@@ -56,16 +58,18 @@ class frenctoolsTimeAverager(timeAverager):
         # Loop through each month and select the corresponding data
             for month_index in month_indices:
                 month_name = month_names[month_index - 1]
-                output_file = month_file_paths[month_name]
+                nc_monthly_file = month_file_paths[month_name]
 
                 # Select data for the given month
-                cdo.select(f"month={month_index}", input=infile, output=output_file)
+                cdo.select(f"month={month_index}", input=infile, output=nc_monthly_file)
 
+                #run timavg command for newly created file
+                month_output_file_name = outfile
                 #Delete files after being used to generate output files
             #for month_index in month_indices:  
              #   month_name = month_names[month_index - 1]
-              #  output_file = month_file_paths[month_name]              
-               # os.remove(output_file)
+              #  nc_monthly_file = month_file_paths[month_name]              
+               # os.remove(nc_monthly_file)
            # os.rmdir('monthly_outputs')    
 ########################################################################################
 

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -44,10 +44,8 @@ class frenctoolsTimeAverager(timeAverager):
             fre_logger.warning('No output filename given, setting outfile= %s', outfile)
         
         #check for existence of timavg.csh. If not found, issue might be that user is not in env with frenctools.
-        try:
-            shutil.which('timavg.csh')
-        except:
-            raise fre_logger.error('did not find timavg.csh')
+        if shutil.which('timavg.csh') == None:
+            fre_logger.error('did not find timavg.csh')
             
         from subprocess import Popen, PIPE
 
@@ -90,10 +88,7 @@ class frenctoolsTimeAverager(timeAverager):
                         exitstatus=0
                         
                 #Delete files after being used to generate output files
-            for month_index in month_indices:  
-                nc_monthly_file = nc_month_file_paths[month_index]              
-                os.remove(nc_monthly_file)
-            os.rmdir('monthly_nc_files')    
+            shutil.rmtree('monthly_nc_files')    
 
         if self.avg_type == 'month':   #End here if month variable used
             return exitstatus

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -1,5 +1,6 @@
 ''' class for utilizing timavg.csh (aka script to TAVG fortran exe) in frenc-tools '''
 from .timeAverager import timeAverager
+import os 
 
 class frenctoolsTimeAverager(timeAverager):
     '''
@@ -35,7 +36,33 @@ class frenctoolsTimeAverager(timeAverager):
             print(f'WARNING: no output filename given, setting outfile={outfile}')
 
         from subprocess import Popen, PIPE
+########################################################################################
+        #recursive call if month is selcted for climatology. by Avery Kiihne
+        if self.avg_type == 'month':
+            output_dir = f"monthly_outputs"
+            os.makedirs(output_dir, exist_ok=True)
+            # Extract unique months from the infile 
+            with Dataset(infile) as ds:
+                times = ds.variables['time'][:]
+                dates = num2date(times, units=ds.variables['time'].units)
+            unique_month_names = sorted(set((date.month, date.year) for date in dates))
+            # Dictionary to store output filenames by month
+            month_file_names = {month: os.path.join(output_dir, f"{month:02d}_all_years.nc") for month, _ in unique_month_names}
 
+            # Loop through each month and select the corresponding data
+            for month, _ in unique_month_names:
+                # Select data for the given month
+                cdo.select(f"month={month}", input=infile, output=month_file_names[month])
+            
+                print(f"Created file for month {month}: {month_file_names[month]}")
+
+                #Delete files after being used to generate output files
+                for file in month_file_names:
+                    os.remove(file)
+                    
+########################################################################################
+
+            
         timavgcsh_command=['timavg.csh', '-mb','-o', outfile, infile]
         exitstatus=1
         with Popen(timavgcsh_command,

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -42,7 +42,7 @@ class frenctoolsTimeAverager(timeAverager):
         
         #check for existence of timavg.csh. If not found, issue might be that user is not in env with frenctools.
         if shutil.which('timavg.csh') is None:
-            raise ValueError'did not find timavg.csh')
+            raise ValueError('did not find timavg.csh')
             
         from subprocess import Popen, PIPE
 

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -41,7 +41,11 @@ class frenctoolsTimeAverager(timeAverager):
         if outfile is None:
             outfile='frenctoolsTimeAverage_'+infile
             fre_logger.warning('No output filename given, setting outfile= %s', outfile)
-
+        try:
+            subprocess.run(['which timavg.csh'], shell = True)
+        except:
+            fre_logger.error('did not find timavg.csh')
+            
         from subprocess import Popen, PIPE
 ########################################################################################
         #Recursive call if month is selcted for climatology. by Avery Kiihne
@@ -74,10 +78,7 @@ class frenctoolsTimeAverager(timeAverager):
                         stdout=PIPE, stderr=PIPE, shell=False) as subp:
                     output=subp.communicate()[0]
                             
-                    try:
-                        subprocess.run(['which timavg.csh'], shell = True)
-                    except:
-                        fre_logger.error('did not find timavg.csh')
+
                         
                     if subp.returncode < 0:
                         fre_logger.error('error')

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -2,6 +2,8 @@
 from .timeAverager import timeAverager
 import os 
 from netCDF4 import Dataset
+from cdo import Cdo
+cdo = Cdo()
 
 class frenctoolsTimeAverager(timeAverager):
     '''
@@ -44,13 +46,13 @@ class frenctoolsTimeAverager(timeAverager):
             os.makedirs(output_dir, exist_ok=True)
             # Extract unique months from the infile 
 
-            unique_month_names = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+            unique_month_names = sorted(["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"])
 
             # Dictionary to store output filenames by month
-            month_file_names = {month: os.path.join(output_dir, f"{month:02d}_all_years.nc") for month, _ in unique_month_names}
+            month_file_names = {month: os.path.join(output_dir, f"{month}_all_years.nc") for month in unique_month_names}
 
             # Loop through each month and select the corresponding data
-            for month, _ in unique_month_names:
+            for month in unique_month_names:
                 # Select data for the given month
                 cdo.select(f"month={month}", input=infile, output=month_file_names[month])
             

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -54,19 +54,19 @@ class frenctoolsTimeAverager(timeAverager):
             month_names = [calendar.month_name[i] for i in month_indices]
 
             #Dictionary to store output filenames by month
-            nc_month_file_paths = {month: os.path.join(monthly_nc_dir, f"{month}_all_years.nc") for month in month_names}
-            month_output_file_paths = {number: os.path.join(output_dir, f"{outfile}_.{number}.nc") for number in month_indices}
+            nc_month_file_paths = {month_index: os.path.join(monthly_nc_dir, f"{month}_all_years.nc") for month_index in month_indices}
+            month_output_file_paths = {month_index: os.path.join(output_dir, f"{outfile}_.{number}.nc") for month_index in month_indices}
 
             #Loop through each month and select the corresponding data
             for month_index in month_indices:
                 month_name = month_names[month_index - 1]
-                nc_monthly_file = nc_month_file_paths[month_name]
+                nc_monthly_file = nc_month_file_paths[month_index]
 
                 #Select data for the given month
                 cdo.select(f"month={month_index}", input=infile, output=nc_monthly_file)
 
                 #Run timavg command for newly created file
-                month_output_file = month_output_file_paths[month_name]
+                month_output_file = month_output_file_paths[month_index]
                 timavgcsh_command=['timavg.csh', '-mb','-o', month_output_file, nc_monthly_file]
                 exitstatus=1
                 with Popen(timavgcsh_command,
@@ -86,8 +86,7 @@ class frenctoolsTimeAverager(timeAverager):
                         
                 #Delete files after being used to generate output files
             for month_index in month_indices:  
-                month_name = month_names[month_index - 1]
-                nc_monthly_file = nc_month_file_paths[month_name]              
+                nc_monthly_file = nc_month_file_paths[month_index]              
                 os.remove(nc_monthly_file)
             os.rmdir('monthly_nc_files')    
 

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -37,7 +37,7 @@ class frenctoolsTimeAverager(timeAverager):
 
         if infile is None:
             fre_logger.error('Need an input file, specify a value for the infile argument')
-            return exitstatus
+            raise exitstatus
 
         if outfile is None:
             outfile='frenctoolsTimeAverage_'+infile
@@ -91,7 +91,7 @@ class frenctoolsTimeAverager(timeAverager):
             shutil.rmtree('monthly_nc_files')    
 
         if self.avg_type == 'month':   #End here if month variable used
-            return exitstatus
+            raise exitstatus
         
         timavgcsh_command=['timavg.csh', '-mb','-o', outfile, infile]
         exitstatus=1
@@ -106,4 +106,4 @@ class frenctoolsTimeAverager(timeAverager):
                 fre_logger.info('climatology successfully ran')
                 exitstatus=0
 
-        return exitstatus
+        raise exitstatus

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -14,7 +14,7 @@ class frenctoolsTimeAverager(timeAverager):
             print(locals()) #input argument details
 
         exitstatus=1
-        if self.avg_type!='all':
+        if self.avg_type!='all' or 'monthly':
             print(f'ERROR: avg_type={self.avg_type} not supported by this class at this time.')
             return exitstatus
 

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -14,7 +14,8 @@ class frenctoolsTimeAverager(timeAverager):
             print(locals()) #input argument details
 
         exitstatus=1
-        if self.avg_type!='all' or 'monthly':
+        if self.avg_type not in ['month','all']:
+            print('correct location')
             print(f'ERROR: avg_type={self.avg_type} not supported by this class at this time.')
             return exitstatus
 

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -73,7 +73,7 @@ class frenctoolsTimeAverager(timeAverager):
                         stdout=PIPE, stderr=PIPE, shell=False) as subp:
                     output=subp.communicate()[0]
                             
-                    if pathlib.Path.exists("timavg.csh"):
+                    if os.path.exists("timavg.csh"):
                         continue
                     else:
                         fre_logger.error("No timavg.csh file found")

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -6,6 +6,7 @@ import calendar
 from cdo import Cdo
 import logging
 import subprocess
+import shutil
 
 cdo = Cdo()
 fre_logger = logging.getLogger(__name__)
@@ -41,8 +42,9 @@ class frenctoolsTimeAverager(timeAverager):
         if outfile is None:
             outfile='frenctoolsTimeAverage_'+infile
             fre_logger.warning('No output filename given, setting outfile= %s', outfile)
+            
         try:
-            subprocess.run(['which timavg.csh'], shell = True)
+            shutil.which('timavg.csh')
         except:
             raise fre_logger.error('did not find timavg.csh')
             

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -24,7 +24,7 @@ class frenctoolsTimeAverager(timeAverager):
 
         exitstatus=1
         if self.avg_type not in ['month','all']:
-            raise FileError(f'avg_type= {self.avg_type} not supported by this class at this time.')
+            raise ValueError(f'avg_type= {self.avg_type} not supported by this class at this time.')
 
         if self.unwgt:
             fre_logger.warning('unwgt=True unsupported by frenctoolsAverager. Ignoring!!!')

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -50,7 +50,7 @@ class frenctoolsTimeAverager(timeAverager):
             month_names = [calendar.month_name[i] for i in month_indices]
 
             # Dictionary to store output filenames by month
-            month_file_names = {month: os.path.join(output_dir, f"{month}_all_years.nc") for month in unique_month_names}
+            month_file_paths = {month: os.path.join(output_dir, f"{month}_all_years.nc") for month in month_names}
 
             # Loop through each month and select the corresponding data
         # Loop through each month and select the corresponding data
@@ -61,11 +61,12 @@ class frenctoolsTimeAverager(timeAverager):
                 # Select data for the given month
                 cdo.select(f"month={month_index}", input=infile, output=output_file)
 
-
                 #Delete files after being used to generate output files
-                for file in month_file_names:
-                    os.remove(file)
-                    
+            #for month_index in month_indices:  
+             #   month_name = month_names[month_index - 1]
+              #  output_file = month_file_paths[month_name]              
+               # os.remove(output_file)
+           # os.rmdir('monthly_outputs')    
 ########################################################################################
 
             

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -43,7 +43,7 @@ class frenctoolsTimeAverager(timeAverager):
         
         #check for existence of timavg.csh. If not found, issue might be that user is not in env with frenctools.
         if shutil.which('timavg.csh') == None:
-            fre_logger.error('did not find timavg.csh')
+            raise fre_logger.error('did not find timavg.csh')
             
         from subprocess import Popen, PIPE
 

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -25,8 +25,7 @@ class frenctoolsTimeAverager(timeAverager):
 
         exitstatus=1
         if self.avg_type not in ['month','all']:
-            fre_logger.error('avg_type= %s not supported by this class at this time.', self.avg_type)
-            return exitstatus
+            raise fre_logger.error('avg_type= %s not supported by this class at this time.', self.avg_type)
 
         if self.unwgt:
             fre_logger.warning('unwgt=True unsupported by frenctoolsAverager. Ignoring!!!')
@@ -36,8 +35,7 @@ class frenctoolsTimeAverager(timeAverager):
                    ' not currently supported for frenctols time averaging. ignoring!', self.var)
 
         if infile is None:
-            fre_logger.error('Need an input file, specify a value for the infile argument')
-            raise exitstatus
+            raise fre_logger.error('Need an input file, specify a value for the infile argument')
 
         if outfile is None:
             outfile='frenctoolsTimeAverage_'+infile

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -55,7 +55,7 @@ class frenctoolsTimeAverager(timeAverager):
 
             #Dictionary to store output filenames by month
             nc_month_file_paths = {month: os.path.join(monthly_nc_dir, f"{month}_all_years.nc") for month in month_names}
-            month_output_file_paths = {month: os.path.join(output_dir, f"{outfile}_.{number}.nc") for number in month_indices}
+            month_output_file_paths = {number: os.path.join(output_dir, f"{outfile}_.{number}.nc") for number in month_indices}
 
             #Loop through each month and select the corresponding data
             for month_index in month_indices:

--- a/fre/app/generate_time_averages/frenctoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frenctoolsTimeAverager.py
@@ -41,30 +41,29 @@ class frenctoolsTimeAverager(timeAverager):
 
         from subprocess import Popen, PIPE
 ########################################################################################
-        #recursive call if month is selcted for climatology. by Avery Kiihne
+        #Recursive call if month is selcted for climatology. by Avery Kiihne
         if self.avg_type == 'month':
-            monthly_nc_dir = f"monthly_nc_files"
-            output_dir = f"monthly_output_files"
-            os.makedirs(monthly_nc_dir, exist_ok=True)
+            monthly_nc_dir = f"monthly_nc_files"    #Folder that new monthly input files are put 
+            output_dir = f"monthly_output_files"    #Folder for the results, split by month
+            os.makedirs(monthly_nc_dir, exist_ok=True)   #create directory if it does not exist
             os.makedirs(output_dir, exist_ok=True)
-            # Extract unique months from the infile 
+            #Extract unique months from the infile 
             month_indices = list(range(1, 13))
             month_names = [calendar.month_name[i] for i in month_indices]
 
-            # Dictionary to store output filenames by month
+            #Dictionary to store output filenames by month
             nc_month_file_paths = {month: os.path.join(monthly_nc_dir, f"{month}_all_years.nc") for month in month_names}
             month_output_file_paths = {month: os.path.join(output_dir, f"{month}_{outfile}") for month in month_names}
 
-            # Loop through each month and select the corresponding data
-        # Loop through each month and select the corresponding data
+            #Loop through each month and select the corresponding data
             for month_index in month_indices:
                 month_name = month_names[month_index - 1]
                 nc_monthly_file = nc_month_file_paths[month_name]
 
-                # Select data for the given month
+                #Select data for the given month
                 cdo.select(f"month={month_index}", input=infile, output=nc_monthly_file)
 
-                #run timavg command for newly created file
+                #Run timavg command for newly created file
                 month_output_file = month_output_file_paths[month_name]
                 timavgcsh_command=['timavg.csh', '-mb','-o', month_output_file, nc_monthly_file]
                 exitstatus=1
@@ -84,9 +83,11 @@ class frenctoolsTimeAverager(timeAverager):
                 nc_monthly_file = nc_month_file_paths[month_name]              
                 os.remove(nc_monthly_file)
             os.rmdir('monthly_nc_files')    
-########################################################################################
 
-            
+        if self.avg_type == 'month':   #End here if month variable used
+            return exitstatus
+########################################################################################
+        
         timavgcsh_command=['timavg.csh', '-mb','-o', outfile, infile]
         exitstatus=1
         with Popen(timavgcsh_command,

--- a/fre/app/generate_time_averages/tests/test_generate_time_averages.py
+++ b/fre/app/generate_time_averages/tests/test_generate_time_averages.py
@@ -433,6 +433,7 @@ def test_fre_nctool_time_unwgt_avgs_stddevs():
 
 '''
 #
+#if pl.Path archive exists, run these tests
 def test_fre_nctools_all():
     ''' generates a time averaged file using fre_cli's version '''
     ''' weighted average, no std deviation '''

--- a/fre/app/generate_time_averages/tests/test_generate_time_averages.py
+++ b/fre/app/generate_time_averages/tests/test_generate_time_averages.py
@@ -433,21 +433,21 @@ def test_fre_nctool_time_unwgt_avgs_stddevs():
 
 # This set of tests is for the monthly frenctools option
 def test_fre_nctools_all():
-    # generates a time averaged file using fre_cli's version 
-    # weighted average, no std deviation 
+    # tests run of frenctools climatology with all flag
     assert run_avgtype_pkg_calculations(
         infile  = (time_avg_file_dir+test_file_name),
         outfile = (time_avg_file_dir+'frepytools_timavg_'+test_file_name),
         pkg='fre-nctools',avg_type='all', unwgt=False )
     
 def test_fre_nctools_month():
-    # generates a time averaged file using fre_cli's version 
-    # weighted average, no std deviation 
+    # tests run of frenctools climatology with month flag
     assert run_avgtype_pkg_calculations(
         infile  = (time_avg_file_dir+test_file_name),
         outfile = (time_avg_file_dir+'frepytools_timavg_'+test_file_name),
         pkg='fre-nctools',avg_type='month', unwgt=False )
+        
 def test_path_frenctools_month():
+    #tests if files are being generated in the right spot for frenctools monthly climatology
     run_avgtype_pkg_calculations(
         infile  = (time_avg_file_dir+test_file_name),
         outfile = (time_avg_file_dir+'frepytools_timavg_'+test_file_name),

--- a/fre/app/generate_time_averages/tests/test_generate_time_averages.py
+++ b/fre/app/generate_time_averages/tests/test_generate_time_averages.py
@@ -431,20 +431,18 @@ def test_fre_nctool_time_unwgt_avgs_stddevs():
         outfile = (time_avg_file_dir+'fre_nctools_unwgt_stddev_'+two_out_file_name),
         pkg='fre-nctools',avg_type='all',  unwgt=True )
 
-'''
-#
-#if pl.Path archive exists, run these tests
+# This set of tests is for the monthly frenctools option
 def test_fre_nctools_all():
-    ''' generates a time averaged file using fre_cli's version '''
-    ''' weighted average, no std deviation '''
+    # generates a time averaged file using fre_cli's version 
+    # weighted average, no std deviation 
     assert run_avgtype_pkg_calculations(
         infile  = (time_avg_file_dir+test_file_name),
         outfile = (time_avg_file_dir+'frepytools_timavg_'+test_file_name),
         pkg='fre-nctools',avg_type='all', unwgt=False )
     
 def test_fre_nctools_month():
-    ''' generates a time averaged file using fre_cli's version '''
-    ''' weighted average, no std deviation '''
+    # generates a time averaged file using fre_cli's version 
+    # weighted average, no std deviation 
     assert run_avgtype_pkg_calculations(
         infile  = (time_avg_file_dir+test_file_name),
         outfile = (time_avg_file_dir+'frepytools_timavg_'+test_file_name),
@@ -455,3 +453,4 @@ def test_path_frenctools_month():
         outfile = (time_avg_file_dir+'frepytools_timavg_'+test_file_name),
         pkg='fre-nctools',avg_type='month', unwgt=False )
     assert pl.Path(time_avg_file_dir+'../monthly_output_files/April_out.nc').exists()
+'''

--- a/fre/app/generate_time_averages/tests/test_generate_time_averages.py
+++ b/fre/app/generate_time_averages/tests/test_generate_time_averages.py
@@ -432,3 +432,19 @@ def test_fre_nctool_time_unwgt_avgs_stddevs():
         pkg='fre-nctools',avg_type='all',  unwgt=True )
 
 '''
+#
+def test_fre_nctools_all():
+    ''' generates a time averaged file using fre_cli's version '''
+    ''' weighted average, no std deviation '''
+    assert run_avgtype_pkg_calculations(
+        infile  = (time_avg_file_dir+test_file_name),
+        outfile = (time_avg_file_dir+'frepytools_timavg_'+test_file_name),
+        pkg='fre-nctools',avg_type='all', unwgt=False )
+    
+def test_fre_nctools_month():
+    ''' generates a time averaged file using fre_cli's version '''
+    ''' weighted average, no std deviation '''
+    assert run_avgtype_pkg_calculations(
+        infile  = (time_avg_file_dir+test_file_name),
+        outfile = (time_avg_file_dir+'frepytools_timavg_'+test_file_name),
+        pkg='fre-nctools',avg_type='month', unwgt=False )

--- a/fre/app/generate_time_averages/tests/test_generate_time_averages.py
+++ b/fre/app/generate_time_averages/tests/test_generate_time_averages.py
@@ -448,3 +448,9 @@ def test_fre_nctools_month():
         infile  = (time_avg_file_dir+test_file_name),
         outfile = (time_avg_file_dir+'frepytools_timavg_'+test_file_name),
         pkg='fre-nctools',avg_type='month', unwgt=False )
+def test_path_frenctools_month():
+    run_avgtype_pkg_calculations(
+        infile  = (time_avg_file_dir+test_file_name),
+        outfile = (time_avg_file_dir+'frepytools_timavg_'+test_file_name),
+        pkg='fre-nctools',avg_type='month', unwgt=False )
+    assert pl.Path(time_avg_file_dir+'../monthly_output_files/April_out.nc').exists()


### PR DESCRIPTION
## Describe your changes
expanded fre-cli/fre/app/generate_time_averages/frenctoolsTimeAverager.py to include option for monthly climatology. Functions by breaking apart netcdf input file into monthly chunks, and then recursively running over each of those with a timavg command. after, deletes the folder and new input nc files. leaves behind a folder labeled "monthly_output_files", with the outputs inside being named {Month}_{user requested output name}. Also added several tests.

## Issue ticket number and link (if applicable)
Monthly climatologies using fre-nctools backend #391

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [x] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module
