### PR TITLE
add link time optimization option as a target

### DIFF
--- a/fre/make/gfdlfremake/targetfre.py
+++ b/fre/make/gfdlfremake/targetfre.py
@@ -43,6 +43,10 @@ class fretarget:
             else:
                 self.openmp = False
 
+            ## Check if lto is given to turn on link time optimization
+            if target == "lto":
+                self.makeline_add = self.makeline_add + "USE_LTO=on "
+
         ## Check to make sure only one of the prod, debug, repro are used
         errormsg = "You can only list one mutually exclusive target, but your target '"+self.target+"' lists more than one of the following targets: \n debug \n prod \n repro"
         if self.debug:


### PR DESCRIPTION
## Describe your changes
Adds a conditional to turn on link time optimization via mkmf when 'lto' is included in the target. Its used like openmp so is specified in addition to the standard prod/debug/repro name.

## Issue ticket number and link (if applicable)

relies on this PR to add the mkmf option: https://github.com/NOAA-GFDL/mkmf/pull/77

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [x] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [x] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module
