### PR TITLE
Updates for proposed changes to PP yaml format

### DIFF
--- a/docs/usage/yaml_dev/pp_yaml.rst
+++ b/docs/usage/yaml_dev/pp_yaml.rst
@@ -49,8 +49,7 @@ This file can follow the format below:
        history_segment: "amount of time covered by a single history file (ISO8601 datetime)"                              (string)
        pp_start: "start of the desired postprocessing (ISO8601 datetime)"                                                 (string)
        pp_stop: "end of the desired postprocessing (ISO8601 datetime)"                                                    (string)
-       pp_chunk_a: "amount of time covered by a single postprocessed file (ISO8601 datetime)"                             (string)
-       pp_chunk_b: "secondary chunk size for postprocessed files, if desired (ISO8601 datetime). Divisble by pp_chunk_a"  (string)
+       pp_chunks: "array of ISO8601 datetime durations, specifying the interval of simulated time per postprocessed file" (string)
        pp_grid_spec: "path to FMS grid definition tarfile"                                                                (string)
      switches:
        do_timeavgs: "switch to turn on/off time-average file generation"                                                  (boolean)
@@ -68,7 +67,7 @@ Required keys include:
     - ptmp_dir
     - site
     - history_segment
-    - pp_chunk_a
+    - pp_chunks
     - pp_start
     - pp_stop
     - pp_grid_spec

--- a/fre/pp/configure_script_xml.py
+++ b/fre/pp/configure_script_xml.py
@@ -546,22 +546,13 @@ def main(xml, platform, target, experiment, do_analysis, historydir, refinedir, 
     # Process all of the found PP chunks into the rose-suite configuration
     fre_logger.info("Setting PP chunks...")
 
-    sorted_chunks = list(chunks)
-    sorted_chunks.sort(key=duration_to_seconds, reverse=False)
-
     if len(chunks) == 0:
         raise ValueError('no chunks found! exit.')
 
+    sorted_chunks = list(chunks)
+    sorted_chunks.sort(key=duration_to_seconds, reverse=False)
     fre_logger.info("  Chunks found: %s", ', '.join(sorted_chunks))
-    if len(chunks) == 1:
-        rose_suite.set(['template variables', 'PP_CHUNK_A'],
-                       f"'{sorted_chunks[0]}'")
-    else:
-        rose_suite.set(['template variables', 'PP_CHUNK_A'],
-                       f"'{sorted_chunks[0]}'")
-        rose_suite.set(['template variables', 'PP_CHUNK_B'],
-                       f"'{sorted_chunks[1]}'")
-    fre_logger.info("  Chunks used: %s", ', '.join(sorted_chunks[0:2]) )
+    rose_suite.set(['template variables', 'PP_CHUNKS'], f"{sorted_chunks}")
 
     # Write out the final configurations.
     fre_logger.info("Writing output files...")

--- a/fre/pp/edits-template.yaml
+++ b/fre/pp/edits-template.yaml
@@ -36,10 +36,8 @@ rose-suite:
     site:
     # Location for shared analysis scripts
     fre_analysis_home:
-    # ISO8601 duration of the desired post-processed output
-    pp_chunk_a:
-    # ISO8601 duration of a second desired postprocessed output
-    pp_chunk_b:
+    # Array of ISO8601 durations specifying the interval of simulated time per postprocessed output file
+    pp_chunks:
     # Components to be post-processed
     pp_components:
     # Default regridded resolution

--- a/fre/pp/tests/AM5_example/yaml_include/settings.yaml
+++ b/fre/pp/tests/AM5_example/yaml_include/settings.yaml
@@ -12,7 +12,8 @@ postprocess:
     site:               "ppan"
     pp_start:   *ANA_AMIP_START
     pp_stop:    *ANA_AMIP_END
-    pp_chunk_a: *PP_AMIP_CHUNK96
+    pp_chunks:
+      - *PP_AMIP_CHUNK96
     pp_grid_spec: *GRID_SPEC96
   switches: &shared_switches
     do_timeavgs:        True

--- a/fre/yamltools/tests/AM5_example/analysis_yamls/clouds.yaml
+++ b/fre/yamltools/tests/AM5_example/analysis_yamls/clouds.yaml
@@ -5,7 +5,7 @@ analysis:
       date_range: [*ANA_AMIP_START, *ANA_AMIP_END]
     workflow:
       components: ["atmos-test"]
-      cumulative: False
+      script_type: 'independent'
       product: 'ts'
-      script_frequency: *PP_AMIP_CHUNK96
+      chunk_size: *PP_AMIP_CHUNK96
       analysis_on: True

--- a/fre/yamltools/tests/AM5_example/analysis_yamls/land.yaml
+++ b/fre/yamltools/tests/AM5_example/analysis_yamls/land.yaml
@@ -5,7 +5,7 @@ analysis:
       date_range: [*ANA_AMIP_START, *ANA_AMIP_END]
     workflow:
       components: ["land-test"]
-      cumulative: False
+      script_type: 'one-shot'
       product: 'ts'
-      script_frequency: 'R1'
+      chunk_size: *PP_AMIP_CHUNK96
       analysis_on: True

--- a/fre/yamltools/tests/AM5_example/pp_yamls/settings.yaml
+++ b/fre/yamltools/tests/AM5_example/pp_yamls/settings.yaml
@@ -12,7 +12,8 @@ postprocess:
     site:               "ppan"
     pp_start:   *ANA_AMIP_START
     pp_stop:    *ANA_AMIP_END
-    pp_chunk_a: *PP_AMIP_CHUNK96
+    pp_chunks:
+      - *PP_AMIP_CHUNK96
     pp_grid_spec: *GRID_SPEC96
   switches: &shared_switches
     do_timeavgs:        True


### PR DESCRIPTION
## Describe your changes
The code, documentation, tests, and templates have been updated in accordance with the changes to the PP yaml format proposed in NOAA-GFDL/gfdl_msd_schemas#28:
- Replace `pp_chunk_a` and `pp_chunk_b` with an array called `pp_chunks`
- Replace `cumulative` and `script_frequency` with `script_type` and `chunk_size` in analysis script configurations.

This should be tested in conjunction with NOAA-GFDL/gfdl_msd_schemas#28 and NOAA-GFDL/fre-workflows#69.

## Issue ticket number and link
#409

## Checklist before requesting a review

- [ ] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [x] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module