### PR TITLE
Do not quote lists in rose-suite.conf

### DIFF
--- a/fre/pp/configure_script_yaml.py
+++ b/fre/pp/configure_script_yaml.py
@@ -73,8 +73,6 @@ def rose_init(experiment,platform,target):
     rose_suite = metomi.rose.config.ConfigNode()
     # disagreeable; these should be optional
     rose_suite.set(keys=['template variables', 'DO_ANALYSIS_ONLY'],  value='False')
-    rose_suite.set(keys=['template variables', 'DO_MDTF'],  value='False')
-    rose_suite.set(keys=['template variables', 'PP_DEFAULT_XYINTERP'],  value='0,0')
 
     # set some rose suite vars
     rose_suite.set(keys=['template variables', 'EXPERIMENT'], value=f'"{experiment}"')
@@ -95,9 +93,11 @@ def rose_init(experiment,platform,target):
 def quote_rose_values(value):
     """
     rose-suite.conf template variables must be quoted unless they are
-    boolean, in which case do not quote them.
+    boolean or a list, in which case do not quote them.
     """
     if isinstance(value, bool):
+        return f"{value}"
+    elif isinstance(value, list):
         return f"{value}"
     else:
         return "'" + str(value) + "'"

--- a/fre/pp/configure_script_yaml.py
+++ b/fre/pp/configure_script_yaml.py
@@ -73,6 +73,8 @@ def rose_init(experiment,platform,target):
     rose_suite = metomi.rose.config.ConfigNode()
     # disagreeable; these should be optional
     rose_suite.set(keys=['template variables', 'DO_ANALYSIS_ONLY'],  value='False')
+    rose_suite.set(keys=['template variables', 'DO_MDTF'],  value='False')
+    rose_suite.set(keys=['template variables', 'PP_DEFAULT_XYINTERP'],  value='0,0')
 
     # set some rose suite vars
     rose_suite.set(keys=['template variables', 'EXPERIMENT'], value=f'"{experiment}"')

--- a/fre/pp/tests/test_rose_quoting.py
+++ b/fre/pp/tests/test_rose_quoting.py
@@ -8,3 +8,7 @@ def test_boolean():
 def test_string():
     ''' check that string values with quotes are handled correctly by rose'''
     assert quote_rose_values('foo') == "'foo'"
+
+def test_list():
+    ''' check that lists are handled correctly by rose'''
+    assert quote_rose_values(['a', 'b', 3]) == "['a', 'b', 3]"


### PR DESCRIPTION
## Describe your changes
#421 caused 'fre pp configure-yaml' to write incorrect lists to rose-suite.conf. The double quoting is not allowed.

```
PP_CHUNKS='['P1Y']'
```

This update adds a check in `quote_rose_values` for whether the config item is a `list` and if so skips the quoting.

## Issue ticket number and link (if applicable)

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module
