### PR TITLE
cleanup working for generate_time_averages, run_fremake_builds

### DIFF
--- a/fre/app/generate_time_averages/tests/test_generate_time_averages.py
+++ b/fre/app/generate_time_averages/tests/test_generate_time_averages.py
@@ -402,9 +402,10 @@ def test_fre_cli_app_gen_time_avg_cleanup():
     ''' Removes all .nc files in fre/app/generate_time_averages/tests/test_data/ '''
     nc_files = [os.path.join(time_avg_file_dir, el) for el in os.listdir(time_avg_file_dir)
                  if el.endswith(".nc")]
+    nc_files = [pl.Path(el) for el in nc_files]
     for nc in nc_files:
-        pl.Path.unlink(pl.Path(nc))
-    nc_remove = [not pl.Path.exists(pl.Path(el)) for el in nc_files]
+        pl.Path.unlink(nc)
+    nc_remove = [not pl.Path.exists(el) for el in nc_files]
     assert all(nc_remove)
 
 '''

--- a/fre/app/generate_time_averages/tests/test_generate_time_averages.py
+++ b/fre/app/generate_time_averages/tests/test_generate_time_averages.py
@@ -2,6 +2,7 @@
 import pathlib as pl
 import pytest
 import subprocess
+import os
 
 def run_avgtype_pkg_calculations(infile=None,outfile=None, pkg=None, avg_type=None, unwgt=None):
     ''' test-harness function, called by other test functions. '''
@@ -396,6 +397,16 @@ def test_fre_cli_time_unwgt_avgs_stddevs_two_files():
         infile  = (two_test_file_names),
         outfile = (time_avg_file_dir+'frepytools_unwgt_stddev_'+two_out_file_name),
         pkg='fre-python-tools',avg_type='all',  unwgt=True )
+
+def test_fre_cli_app_gen_time_avg_cleanup():
+    ''' Removes all .nc files in fre/app/generate_time_averages/tests/test_data/ '''
+    nc_files = [os.path.join(time_avg_file_dir, el) for el in os.listdir(time_avg_file_dir)
+                 if el.endswith(".nc")]
+    for nc in nc_files:
+        pl.Path.unlink(pl.Path(nc))
+    nc_remove = [not pl.Path.exists(pl.Path(el)) for el in nc_files]
+    assert all(nc_remove)
+
 '''
 To be implemnted when fre-nctools has been updated. these options currently work locally if a user has fre-nctools in their conda env.
 ## fre-nctools avgs+stddevs, weighted+unweighted, all ------------------------
@@ -454,3 +465,5 @@ def test_path_frenctools_month():
         pkg='fre-nctools',avg_type='month', unwgt=False )
     assert pl.Path(time_avg_file_dir+'../monthly_output_files/April_out.nc').exists()
 '''
+
+

--- a/fre/app/generate_time_averages/tests/test_generate_time_averages.py
+++ b/fre/app/generate_time_averages/tests/test_generate_time_averages.py
@@ -405,7 +405,7 @@ def test_fre_cli_app_gen_time_avg_cleanup():
     nc_files = [pl.Path(el) for el in nc_files]
     for nc in nc_files:
         pl.Path.unlink(nc)
-    nc_remove = [not pl.Path.exists(el) for el in nc_files]
+    nc_remove = [not pl.Path(el).exists() for el in nc_files]
     assert all(nc_remove)
 
 '''

--- a/fre/make/tests/compilation/test_run_fremake_builds.py
+++ b/fre/make/tests/compilation/test_run_fremake_builds.py
@@ -89,3 +89,14 @@ def test_run_fremake_container_build_notransfer():
     run_fremake_script.fremake_run(YAMLPATH, CONTAINER_PLATFORM, TARGET,
         parallel=False, jobs=1, no_parallel_checkout=True,
         no_format_transfer=True, execute=True, verbose=VERBOSE)
+
+def test_run_fremake_cleanup():
+    ''' removes directories created by the test and checks to make sure they're gone '''
+    dirstrings = ["test_run_fremake_multijob", "test_run_fremake_serial", "test_run_fremake_multitarget"]
+    test_paths = [f"fre/make/tests/{el}/" for el in dirstrings]
+    for tp in test_paths:
+        print(tp)
+        rmtree(tp)
+    tp_remove = [not Path.exists(Path(el)) for el in test_paths]
+    assert all(tp_remove)
+    

--- a/fre/make/tests/compilation/test_run_fremake_builds.py
+++ b/fre/make/tests/compilation/test_run_fremake_builds.py
@@ -95,7 +95,10 @@ def test_run_fremake_cleanup():
     dirstrings = ["test_run_fremake_multijob", "test_run_fremake_serial", "test_run_fremake_multitarget"]
     test_paths = [f"fre/make/tests/{el}/" for el in dirstrings]
     for tp in test_paths:
-        rmtree(tp)
+        try:
+            rmtree(tp)
+        except FileNotFoundError:
+            print(tp + " not found for deletion. Something may have gone wrong elsewhere.")
     tp_remove = [not Path(el).exists() for el in test_paths]
     assert all(tp_remove)
     

--- a/fre/make/tests/compilation/test_run_fremake_builds.py
+++ b/fre/make/tests/compilation/test_run_fremake_builds.py
@@ -95,8 +95,7 @@ def test_run_fremake_cleanup():
     dirstrings = ["test_run_fremake_multijob", "test_run_fremake_serial", "test_run_fremake_multitarget"]
     test_paths = [f"fre/make/tests/{el}/" for el in dirstrings]
     for tp in test_paths:
-        print(tp)
         rmtree(tp)
-    tp_remove = [not Path.exists(Path(el)) for el in test_paths]
+    tp_remove = [not Path(el).exists() for el in test_paths]
     assert all(tp_remove)
     


### PR DESCRIPTION
## Describe your changes
Cleanup functions for the fremake and generate_time_averages tests

## Issue ticket number and link (if applicable)
https://github.com/NOAA-GFDL/fre-cli/issues/424

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [x] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module

I'm skipping the cleanup for /test_cmor_run_subtool_ppan_only.py for the moment because it's turning out to be a bigger job than I thought - and I'd like to get the smaller unit of functionality stowed away and working before taking a deeper dive into why the cmor tests are getting file locking issues.
