### PR TITLE
Pass regrid rose configs through the click arguments

### DIFF
--- a/fre/app/freapp.py
+++ b/fre/app/freapp.py
@@ -53,11 +53,15 @@ def app_cli():
               help = "`defaultxyInterp` / `def_xy_interp` (env var) default lat/lon resolution " + \
                      "for output regridding. (change me? TODO)",
               required = True)
+@click.option("--rose_config",
+              type = str,
+              help = "Path to Rose app configuration (to be removed soon)",
+              required = True)
 def regrid( input_dir, output_dir, begin, tmp_dir,
-            remap_dir, source, grid_spec, def_xy_interp ):
+            remap_dir, source, grid_spec, def_xy_interp, rose_config ):
     ''' regrid target netcdf file '''
     regrid_xy( input_dir, output_dir, begin, tmp_dir,
-               remap_dir, source, grid_spec, def_xy_interp )
+               remap_dir, source, grid_spec, def_xy_interp, rose_config )
 
 @app_cli.command()
 @click.option("-i", "--infile",


### PR DESCRIPTION
## Describe your changes
`fre app regrid` is still reading the old Rose app configuration for now. This update passes the configuration in as an option for now. We'll refactor this to use the yamls very soon.

## Issue ticket number and link (if applicable)

## Checklist before requesting a review

- [ ] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module
