### PR TITLE
hotfix: click 8.2.0 breaks tests

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - noaa-gfdl::analysis_scripts
   - noaa-gfdl::catalogbuilder
   - noaa-gfdl::fre-nctools
-  - conda-forge::click
+  - conda-forge::click<8.2
   - conda-forge::cylc-flow>=8.2.0
   - conda-forge::cylc-rose
   - conda-forge::cmor>=3.10.0

--- a/meta.yaml
+++ b/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - noaa-gfdl::analysis_scripts
     - noaa-gfdl::catalogbuilder
     - noaa-gfdl::fre-nctools
-    - conda-forge::click
+    - conda-forge::click<8.2
     - conda-forge::cylc-flow>=8.2.0
     - conda-forge::cylc-rose
     - conda-forge::cmor>=3.10.0


### PR DESCRIPTION
force click version to be less than 8.2.

