### PR TITLE
Update bare metal executable name to be identical to Bronx fremake

### DIFF
--- a/fre/make/gfdlfremake/makefilefre.py
+++ b/fre/make/gfdlfremake/makefilefre.py
@@ -132,7 +132,7 @@ class makefile():
             fh.write("include $(MK_TEMPLATE)"+"\n")
 
             # Write the main experiment compile
-            fh.write(self.e+".x: "+libstring+"\n")
+            fh.write("fms_"+self.e+".x: "+libstring+"\n")
             fh.write("\t$(LD) $^ $(LDFLAGS) -o $@ $(STATIC_LIBS)"+"\n")
 
         # Write the link line script with user-provided libraries


### PR DESCRIPTION
## Describe your changes
Update `fre make` bare metal executable name to be identical to the executable names used by Bronx fremake

## Issue ticket number and link (if applicable)
#460 

## Checklist before requesting a review

- [ ] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module
