### PR TITLE
Fix capitalization with container tag names

### DIFF
--- a/fre/make/gfdlfremake/buildDocker.py
+++ b/fre/make/gfdlfremake/buildDocker.py
@@ -232,13 +232,16 @@ class container():
         containerOutputLocation = platform["containerOutputLocation"]
 
         self.userScript = ["#!/bin/bash\n"]
-        self.userScript.append(f"{containerBuild} build -f Dockerfile -t {self.e}:{self.target.gettargetName()}\n")
+        registry_tag = self.e.lower()
+        platform_tag = self.target.gettargetName().lower()
+
+        self.userScript.append(f"{containerBuild} build -f Dockerfile -t {registry_tag}:{platform_tag}\n")
 
         if not skip_format_transfer:
             # Remove any previously generated images, if they exist
             self.userScript.append(f"rm -f {containerName}.tar {containerName}.sif\n")
 
-            self.userScript.append(f"{containerBuild} save -o {containerName}.tar localhost/{self.e}:{self.target.gettargetName()}\n")
+            self.userScript.append(f"{containerBuild} save -o {containerName}.tar localhost/{registry_tag}:{platform_tag}\n")
             self.userScript.append(f"{containerRun} build --disable-cache {containerName}.sif docker-archive://{containerName}.tar\n")
             if containerOutputLocation != "":
                 self.userScript.append(f"mkdir -p {containerOutputLocation}\n")


### PR DESCRIPTION
## Describe your changes
Podman tag is not recognized when there is any uppercase letter used. This PR ensures the tag is all lowercase but still keeps the ability to name container however you want (with uppercase letters).

(this was a little bug that was revisited/rediscovered when building a container from esm4.5 configs for testing)

## Issue ticket number and link (if applicable)
#302 

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module
