### PR TITLE
Fix missed NetCDF4 removal in regrid-xy 

### DIFF
--- a/fre/app/regrid_xy/tests/test_fre_regrid_xy_functions.py
+++ b/fre/app/regrid_xy/tests/test_fre_regrid_xy_functions.py
@@ -1,3 +1,7 @@
+import os
+import numpy as np
+import xarray as xr
+
 import fre.app.regrid_xy.regrid_xy
 from . import write_input_files
 
@@ -12,3 +16,35 @@ def test_get_grid_dims():
 
     assert nx==360
     assert ny==90
+
+    #will be more streamlined with the testing project
+    os.remove(grid_spec)
+    os.remove("C96_mosaic.nc")
+    for i in range(1,7): os.remove(f"C96_grid.tile{i}.nc")
+
+
+def test_regrid_var_list():
+
+    testfile = "test.nc"
+    interp_method = "conserve_order1"
+
+    array1, dims1 = np.array([1,2,3]), ["nz"]
+    array2, dims2 = np.array([[1,2,3],[4,5,6]]), ["nx", "ny"]
+    
+    variables=dict(geolon_c = xr.DataArray(array2, dims=dims2),
+                   average_T1 = xr.DataArray(array2, dims=dims2),
+                   variable0 = xr.DataArray(array1, dims=dims1),
+                   variable1 = xr.DataArray(array2, dims=dims2, attrs={"interp_method":"fake_interp"}),
+                   variable2 = xr.DataArray(array2, dims=dims2, attrs={"interp_method":interp_method}),
+                   variable3 = xr.DataArray(array2, dims=dims2),
+    )
+    xr.Dataset(variables).to_netcdf(testfile)
+
+    nvariables, answers = 3, ["variable1", "variable2", "variable3"]
+    
+    varlist = fre.app.regrid_xy.regrid_xy.make_regrid_var_list(testfile, interp_method=interp_method)
+
+    assert nvariables == len(varlist)
+    assert all([varlist[i] == answers[i] for i in range(nvariables)])
+
+    os.remove(testfile)


### PR DESCRIPTION
## Describe your changes
In this PR,

the function `regrid_var_list` in the regrid-xy app has been modified to use `Xarray` instead of the `NetCDF4` package.  
With this change, the function `check_interp_method` has been removed.  Instead, the interp method is checked as part of `regrid_var_list`.  Test `test_regrid_var_list` has also been added.

## Issue ticket number and link #518 

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module
