### PR TITLE
Update README.md to point to read the docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <!-- [![codecov](https://codecov.io/gh/NOAA-GFDL/fre-cli/branch/ghpages.deprecation/graph/badge.svg?token=iGb0wEuWs1)](https://codecov.io/gh/NOAA-GFDL/fre-cli) -->
 [![codecov](https://codecov.io/gh/NOAA-GFDL/fre-cli/graph/badge.svg?token=iGb0wEuWs1)](https://codecov.io/gh/NOAA-GFDL/fre-cli)
 
-* [Documentation](https://noaa-gfdl.github.io/fre-cli/index.html)
+[Fre-cli Documentation](https://noaa-gfdl.readthedocs.io/projects/fre-cli/en/latest/index.html) is hosted on Read the Docs
 
 `fre-cli` is the Flexible Runtime Environment (`FRE`) command-line interface (`CLI`). `fre-cli` aims to gives users intuitive and 
 easy-to-understand access to both newly developed, and legacy `FRE` tools via a `click`-driven CLI, delivered as a `conda` package.


### PR DESCRIPTION
## Describe your changes

We deprecated GitHub pages as of PR #537.  The link in the readme is now broken.  This PR updates that link and points it to the fre-cli read the docs page.

## Issue ticket number and link (if applicable)
Fixes #543

## Checklist before requesting a review

~~- [ ] I ran my code~~
~~- [ ] I tried to make my code readable~~
~~- [ ] I tried to comment my code~~
~~- [ ] I wrote a new test, if applicable~~
~~- [ ] I wrote new instructions/documentation, if applicable~~
~~- [ ] I ran pytest and inspected it's output~~
~~- [ ] I ran pylint and attempted to implement some of it's feedback~~
~~- [ ] No print statements; all user-facing info uses logging module~~
