### PR TITLE
Support the new strict option to fre catalog build

### DIFF
--- a/docs/tools/catalog.rst
+++ b/docs/tools/catalog.rst
@@ -2,15 +2,15 @@
 
 For more complete information on the ``catalogbuilder`` tool, please see its offical `documentation <https://noaa-gfdl.github.io/CatalogBuilder/>`_.
 
-``builder``
+``build``
 -----------
 
 Generate a catalog.
 
 * Builds json and csv format catalogs from user input directory path
-* Minimal Syntax: ``fre catalog builder -i [input path] -o [output path]``
+* Minimal Syntax: ``fre catalog build -i [input path] -o [output path]``
 * Module(s) needed: n/a
-* Example: ``fre catalog builder -i /archive/am5/am5/am5f3b1r0/c96L65_am5f3b1r0_pdclim1850F/gfdl.ncrc5-deploy-prod-openmp/pp -o ~/output --overwrite``
+* Example: ``fre catalog build -i /archive/am5/am5/am5f3b1r0/c96L65_am5f3b1r0_pdclim1850F/gfdl.ncrc5-deploy-prod-openmp/pp -o ~/output --overwrite``
 
 
 ``validate``

--- a/fre/catalog/frecatalog.py
+++ b/fre/catalog/frecatalog.py
@@ -4,9 +4,8 @@ entry point for fre catalog subcommands
 
 import click
 
-#import catalogbuilder
 from catalogbuilder.scripts import gen_intake_gfdl
-from catalogbuilder.scripts import test_catalog
+from catalogbuilder.tests import compval
 from catalogbuilder.scripts import combine_cats
 
 
@@ -32,9 +31,11 @@ def catalog_cli():
 @click.option('--append', is_flag = True, default = False)
 @click.option('--slow', is_flag = True, default = False,
     help = "Open NetCDF files to retrieve additional vocabulary (standard_name and intrafile static variables")
+@click.option('--strict', is_flag = True, default = False,
+    help = "Ensure output catalog is strictly compliant with schema")
 @click.pass_context
-def builder(context, input_path = None, output_path = None, config = None, filter_realm = None,
-            filter_freq = None, filter_chunk = None, verbose = False, overwrite = False, append = False, slow = False):
+def build(context, input_path = None, output_path = None, config = None, filter_realm = None,
+          filter_freq = None, filter_chunk = None, verbose = False, overwrite = False, append = False, slow = False, strict = False):
     # pylint: disable=unused-argument
     """ - Generate .csv and .json files for catalog """
     context.forward(gen_intake_gfdl.create_catalog_cli)
@@ -48,7 +49,7 @@ def builder(context, input_path = None, output_path = None, config = None, filte
 def validate(context, json_path, json_template_path, test_failure):
     # pylint: disable=unused-argument
     """ - Validate a catalog against catalog schema """
-    context.forward(test_catalog.main)
+    context.forward(compval.main)
 
 @catalog_cli.command()
 @click.option('--input', required = True, multiple = True,


### PR DESCRIPTION
## Describe your changes
Add the optional, default off, option to the catalog builder for strict validation.

Also, rename 'fre catalog builder' to 'fre catalog build' for consistency and clarity.

## Issue ticket number and link (if applicable)
Uses this upstream (not yet merged) update https://github.com/NOAA-GFDL/CatalogBuilder/pull/112

## Checklist before requesting a review

- [ ] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module
