### PR TITLE
make `fre_logger` level-change transient in `fre/yamltools/helpers.py`

### DIFF
--- a/fre/yamltools/helpers.py
+++ b/fre/yamltools/helpers.py
@@ -6,10 +6,7 @@ from jsonschema import validate, ValidationError, SchemaError
 import logging
 from . import *
 
-# set logger level to INFO
 fre_logger = logging.getLogger(__name__)
-former_log_level = fre_logger.level
-fre_logger.setLevel(logging.INFO)
 
 def yaml_load(yamlfile):
     """
@@ -42,6 +39,8 @@ def validate_yaml(yaml, schema_path):
     with open(schema_path, 'r') as s:
         schema = json.load(s)
 
+    former_log_level = fre_logger.level
+    fre_logger.setLevel(logging.INFO)
     fre_logger.info("")
     fre_logger.info("Validating YAML information...")
     try:
@@ -50,3 +49,5 @@ def validate_yaml(yaml, schema_path):
         return True
     except:
         raise ValueError("    YAML dictionary NOT VALID.\n")
+    finally:
+        fre_logger.setLevel(former_log_level)


### PR DESCRIPTION
Minor change to `fre/yamltools/helpers.py`: update the `fre_logger` verbosity setting to be transient, restored to the setting originally determined at `import fre` time. stumbled upon in  #429 

This isn't causing anyone perplexing behavior at this time, but it could at some point!