### PR TITLE
Replace fre-nctools conda dependency with building it from source

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -29,6 +29,8 @@ channels:
     - noaa-gfdl
 
 requirements:
+  build:
+    - conda-forge:nco
   host:
     - python=3.11.*
     - pip


### PR DESCRIPTION
## Describe your changes
The noaa-gfdl channel fre-nctools package was built on the GFDL Intel-based workstations, and so does not work with the AMD-based container. But if we build fre-nctools as part of the fre-cli conda build process, then it will by definition be compiled on the correct architecture.

## Issue ticket number and link (if applicable)

## Checklist before requesting a review

- [ ] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module
