### PR TITLE
Update createContainer.sh script created

### DIFF
--- a/fre/make/gfdlfremake/buildDocker.py
+++ b/fre/make/gfdlfremake/buildDocker.py
@@ -235,7 +235,7 @@ class container():
         registry_tag = self.e.lower()
         platform_tag = self.target.gettargetName().lower()
 
-        self.userScript = ["#!/bin/bash\n"]
+        self.userScript = ["#!/bin/bash\n", "set -ex\n"]
         self.userScript.append(f"{containerBuild} build -f Dockerfile -t {registry_tag}:{platform_tag}\n")
 
         if not skip_format_transfer:


### PR DESCRIPTION
## Describe your changes
If a command fails in the createContainer.sh script currently, the script still proceeds through the container build but we don't want this to happen. This PR adds `set -ex` to the script to exit if a command exits with non-zero status

## Issue ticket number and link (if applicable)
#282 

## Checklist before requesting a review

- [ ] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module
