### PR TITLE
switch to `numpy>=2`

### DIFF
--- a/.github/workflows/build_conda.yml
+++ b/.github/workflows/build_conda.yml
@@ -2,7 +2,6 @@ name: build_conda
 on:
   pull_request:
     branches:
-      - main
 
 # cancel running jobs if theres a newer push
 concurrency:

--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -15,7 +15,12 @@ concurrency:
 
 jobs:
   condaenvcreate:
+    name: Test Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13']
     container:
       image: ghcr.io/noaa-gfdl/fre-cli:miniconda24_gcc14_v2
       options: "--privileged --cap-add=sys_admin --cap-add=mknod --device=/dev/fuse --security-opt seccomp=unconfined --security-opt label=disable --security-opt apparmor=unconfined" # needed for podman
@@ -47,7 +52,12 @@ jobs:
       - name: Create fre-cli Environment
         run: |
           echo "creating fre-cli env holding all deps"
+          echo "Testing with Python ${{ matrix.python-version }}"
+          
           conda env create -y -f environment.yml --name fre-cli
+          
+          # Override Python version based on matrix
+          conda install -y -n fre-cli "python=${{ matrix.python-version }}"
 
           echo "listing packages installed in the fre-cli environment"
           conda env list

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,8 @@ dependencies:
   - conda-forge::jsonschema
   - conda-forge::metomi-rose
   - conda-forge::nccmp
-  - conda-forge::numpy==1.26.4
+#  - conda-forge::numpy==1.26.4
+  - conda-forge::numpy>=2
   - conda-forge::pytest
   - conda-forge::pytest-cov
   - conda-forge::pylint

--- a/fre/app/generate_time_averages/cdoTimeAverager.py
+++ b/fre/app/generate_time_averages/cdoTimeAverager.py
@@ -48,9 +48,15 @@ class cdoTimeAverager(timeAverager):
             nc_fin = Dataset(infile, 'r')
 
             time_bnds = nc_fin['time_bnds'][:].copy()
-            wgts = ( np.moveaxis(time_bnds, 0, -1)[1][:].copy() - \
-                     np.moveaxis(time_bnds, 0, -1)[0][:].copy() )
-            wgts_sum = sum(wgts)
+            # Ensure float64 precision for consistent results across numpy versions
+            # NumPy 2.0 changed type promotion rules (NEP 50), so explicit casting
+            # is needed to avoid precision differences
+            time_bnds = np.asarray(time_bnds, dtype=np.float64)
+            # Transpose once to avoid redundant operations
+            time_bnds_transposed = np.moveaxis(time_bnds, 0, -1)
+            wgts = time_bnds_transposed[1] - time_bnds_transposed[0]
+            # Use numpy.sum for consistent dtype handling across numpy versions
+            wgts_sum = np.sum(wgts, dtype=np.float64)
 
             fre_logger.debug('wgts_sum = %s', wgts_sum)
 

--- a/fre/app/generate_time_averages/frepytoolsTimeAverager.py
+++ b/fre/app/generate_time_averages/frepytoolsTimeAverager.py
@@ -81,13 +81,16 @@ class frepytoolsTimeAverager(timeAverager):
         fin_dims = nc_fin.dimensions
         num_time_bnds = fin_dims['time'].size
         if not self.unwgt: #compute sum of weights
-            wgts = ( numpy.moveaxis( time_bnds, 0, -1 )[1][:].copy() - \
-                     numpy.moveaxis( time_bnds, 0, -1 )[0][:].copy() )
+            # Cast to float64 for consistent results across numpy versions (NEP 50 type promotion changes)
+            time_bnds = numpy.asarray(time_bnds, dtype=numpy.float64)
+            # Transpose once to avoid redundant operations
+            time_bnds_transposed = numpy.moveaxis(time_bnds, 0, -1)
+            wgts = time_bnds_transposed[1] - time_bnds_transposed[0]
             # Use numpy.ma.sum only if there are actually masked values in time_bnds
             if has_masked_time_bnds:
-                wgts_sum = numpy.ma.sum(wgts)
+                wgts_sum = numpy.ma.sum(wgts, dtype=numpy.float64)
             else:
-                wgts_sum = sum(wgts)
+                wgts_sum = numpy.sum(wgts, dtype=numpy.float64)
 
             fre_logger.debug('wgts_sum = %s', wgts_sum)
 
@@ -123,8 +126,8 @@ class frepytoolsTimeAverager(timeAverager):
                     if has_masked_data:
                         avgvals[0][lat][lon] = numpy.ma.sum(tim_val_array * wgts) / wgts_sum
                     else:
-                        avgvals[0][lat][lon] = sum( (tim_val_array[tim] * wgts[tim] )
-                                                  for tim in range(num_time_bnds) ) / wgts_sum
+                        # Use numpy.sum for consistent dtype handling across numpy versions
+                        avgvals[0][lat][lon] = numpy.sum(tim_val_array * wgts, dtype=numpy.float64) / wgts_sum
 
                     del tim_val_array
                 del lon_val_array
@@ -139,9 +142,8 @@ class frepytoolsTimeAverager(timeAverager):
                     if has_masked_data:
                         avgvals[0][lat][lon] = numpy.ma.sum(tim_val_array) / num_time_bnds
                     else:
-                        avgvals[0][lat][lon] = sum( # no time sum needed here, b.c. unweighted, so sum
-                            tim_val_array[tim] for tim in range(num_time_bnds)
-                                   ) / num_time_bnds
+                        # Use numpy.sum for consistent dtype handling across numpy versions
+                        avgvals[0][lat][lon] = numpy.sum(tim_val_array, dtype=numpy.float64) / num_time_bnds
 
                     del tim_val_array
                 del lon_val_array

--- a/meta.yaml
+++ b/meta.yaml
@@ -41,7 +41,8 @@ requirements:
     - conda-forge::jsonschema
     - conda-forge::metomi-rose
     - conda-forge::nccmp
-    - conda-forge::numpy==1.26.4
+#    - conda-forge::numpy==1.26.4
+    - conda-forge::numpy>=2
     - conda-forge::python-cdo
     - conda-forge::pyyaml
     - conda-forge::xarray>=2024.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ classifiers = [
     "Environment :: Console",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
 ]
 
 dynamic = [


### PR DESCRIPTION
numpy v2 compatibility, fixes for NEP 50 type promotion changes. nothing too wild.

### what this does
- bumps `numpy==1.26.4` → `numpy>=2` in `environment.yml` and `meta.yaml`
- fixes numerical precision issues in time averaging routines (`cdoTimeAverager`, `frepytoolsTimeAverager`) caused by numpy 2.0's new type promotion rules
- adds explicit `float64` dtype casting and replaces Python's `sum()` with `numpy.sum()` for consistent results across numpy versions
- adds CI matrix testing for Python 3.12 and 3.13
- drops `Python :: 3.11` classifier from `pyproject.toml`
- some workflow trigger tweaks for `build_conda` and `create_test_conda_env`

### TLDR
copilot agent helped with the heavy lifting on the time averager fixes (#721, #722). the core change is straightforward - just switching the numpy pin - but NEP 50 broke some subtle numerical behavior that needed explicit dtype handling to preserve consistent answers.
