### PR TITLE
Make `pull_request.md` the default template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,3 +12,5 @@
 - [ ] I ran pytest and inspected it's output
 - [ ] I ran pylint and attempted to implement some of it's feedback
 - [ ] No print statements; all user-facing info uses logging module
+
+*Note: If you are a code maintainer updating the tag or releasing a new fre-cli version, please use the `release_procedure.md` template. To quickly use this template, open a new pull request, choose your branch, and add `?template=release_procedure.md` to the end of the url.*


### PR DESCRIPTION
We created another PR template for the release/tag procedure and put both templates in PULL_REQUEST_TEMPLATE. However, the PR templates apparently don't work the same as the issue templates, in that you can't choose which template you want to use when opening a PR. 

I think we should keep the pull_request_template.md as a default for development purposes. I added a note for how to easily use the other release_procedure.md template though, whenever we need to. 