### PR TITLE
Use pytest fixtures for temporary paths to fix cwd dependency in fre make tests

### DIFF
--- a/fre/make/tests/compilation/test_run_fremake_builds.py
+++ b/fre/make/tests/compilation/test_run_fremake_builds.py
@@ -14,10 +14,13 @@ import pytest
 
 from fre.make import run_fremake_script
 
+# Compute repo root to make paths absolute
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+
 # command options
-YAMLDIR = "fre/make/tests/null_example"
+YAMLDIR = os.path.join(repo_root, "fre/make/tests/null_example")
 YAMLFILE = "null_model.yaml"
-YAMLPATH = f"{YAMLDIR}/{YAMLFILE}"
+YAMLPATH = os.path.join(YAMLDIR, YAMLFILE)
 PLATFORM = [ "ci.gnu" ]
 CONTAINER_PLATFORM = ["hpcmini.2025"]
 CONTAINER_PLATFORM_2 = ["hpcmini.2025.Specify.Location"]
@@ -25,18 +28,16 @@ TARGET = ["debug"]
 EXPERIMENT = "null_model_full"
 VERBOSE = False
 
-# set up some paths for the tests to build in
-# the TEST_BUILD_DIR env var is used in the null model's platform.yaml
-# so the model root directory path can be changed
-currPath=os.getcwd()
-SERIAL_TEST_PATH=f"{currPath}/fre/make/tests/compilation/serial_build"
-MULTIJOB_TEST_PATH=f"{currPath}/fre/make/tests/compilation/multijob_build"
-CONTAINER_BUILD_TEST_PATH=f"{currPath}/fre/make/tests/compilation/container"
-Path(SERIAL_TEST_PATH).mkdir(parents=True,exist_ok=True)
-Path(MULTIJOB_TEST_PATH).mkdir(parents=True,exist_ok=True)
-Path(CONTAINER_BUILD_TEST_PATH).mkdir(parents=True,exist_ok=True)
-
 # check if we have required programs installed on our current system
+retstat, version = subprocess.getstatusoutput('gcc --version')
+has_gcc = retstat == 0
+retstat, version = subprocess.getstatusoutput('mpicc --version')
+has_mpi = retstat == 0
+retstat, version = subprocess.getstatusoutput('nc-config --version')
+has_ncdf = retstat == 0
+retstat, version = subprocess.getstatusoutput('mkmf -v')
+has_mkmf = retstat == 0
+can_compile = has_gcc and has_mpi and has_ncdf and has_mkmf
 retstat, version = subprocess.getstatusoutput('gcc --version')
 has_gcc = retstat == 0
 retstat, version = subprocess.getstatusoutput('mpicc --version')
@@ -55,44 +56,51 @@ can_container = has_apptainer and has_podman
 
 # test building the null model using gnu compilers
 @pytest.mark.skipif(not can_compile, reason="missing GNU compiler, mpi, netcdf, or mkmf in PATH")
-def test_run_fremake_serial_compile():
+def test_run_fremake_serial_compile(tmp_path):
     ''' run fre make with run-fremake subcommand and build the null model experiment with gnu'''
-    os.environ["TEST_BUILD_DIR"] = SERIAL_TEST_PATH
+    serial_path = tmp_path / "serial_build"
+    serial_path.mkdir()
+    os.environ["TEST_BUILD_DIR"] = str(serial_path)
     run_fremake_script.fremake_run(YAMLPATH, PLATFORM, TARGET,
         nparallel=1, makejobs=1, gitjobs=1, no_parallel_checkout=False,
         no_format_transfer=True, execute=True, verbose=VERBOSE)
     assert Path(
-        f"{SERIAL_TEST_PATH}/fremake_canopy/test/{EXPERIMENT}/{PLATFORM[0]}-{TARGET[0]}/exec/{EXPERIMENT}.x").exists()
+        f"{serial_path}/fremake_canopy/test/{EXPERIMENT}/{PLATFORM[0]}-{TARGET[0]}/exec/{EXPERIMENT}.x").exists()
 
 # same test with a multiple jobs running simultaneously
 @pytest.mark.skipif(not can_compile, reason="missing GNU compiler, mpi, netcdf, or mkmf in PATH")
-def test_run_fremake_multijob_compile():
+def test_run_fremake_multijob_compile(tmp_path):
     ''' test run-fremake parallel compile with gnu'''
-    os.environ["TEST_BUILD_DIR"] = MULTIJOB_TEST_PATH
+    multijob_path = tmp_path / "multijob_build"
+    multijob_path.mkdir()
+    os.environ["TEST_BUILD_DIR"] = str(multijob_path)
     run_fremake_script.fremake_run(YAMLPATH, PLATFORM, TARGET,
         nparallel=1, makejobs=4, gitjobs=4, no_parallel_checkout=False,
         no_format_transfer=False, execute=True, verbose=VERBOSE)
     assert Path(
-        f"{MULTIJOB_TEST_PATH}/fremake_canopy/test/{EXPERIMENT}/{PLATFORM[0]}-{TARGET[0]}/exec/{EXPERIMENT}.x").exists()
+        f"{multijob_path}/fremake_canopy/test/{EXPERIMENT}/{PLATFORM[0]}-{TARGET[0]}/exec/{EXPERIMENT}.x").exists()
 
 # containerized build
 @pytest.mark.skipif(not can_container, reason="missing podman/apptainer")
-def test_run_fremake_container_build():
+def test_run_fremake_container_build(monkeypatch, tmp_path):
     ''' checks image creation for the container build'''
+    monkeypatch.chdir(tmp_path)
     run_fremake_script.fremake_run(YAMLPATH, CONTAINER_PLATFORM, TARGET,
         nparallel=1, makejobs=1, gitjobs=1, no_parallel_checkout=True,
         no_format_transfer=False, execute=True, verbose=VERBOSE)
     assert Path("null_model_full-debug.sif").exists()
 
 @pytest.mark.skipif(not can_container, reason="missing podman/apptainer")
-def test_run_fremake_container_build_specified_out():
+def test_run_fremake_container_build_specified_out(tmp_path):
     ''' checks that the image was copied to the correct specified output location'''
-    os.environ["TEST_BUILD_DIR"] = CONTAINER_BUILD_TEST_PATH
+    container_path = tmp_path / "container"
+    container_path.mkdir()
+    os.environ["TEST_BUILD_DIR"] = str(container_path)
     run_fremake_script.fremake_run(YAMLPATH, CONTAINER_PLATFORM_2, TARGET,
         nparallel=1, makejobs=1, gitjobs=1, no_parallel_checkout=True,
         no_format_transfer=False, execute=True, verbose=VERBOSE)
     assert Path(
-        f"{CONTAINER_BUILD_TEST_PATH}/fremake_canopy/test/null_model_full-debug.sif").exists()
+        f"{container_path}/fremake_canopy/test/null_model_full-debug.sif").exists()
 
 @pytest.mark.skipif(not can_container, reason="missing podman/apptainer")
 def test_run_fremake_container_build_notransfer():
@@ -116,29 +124,30 @@ def test_run_fremake_cleanup():
     assert all(tp_remove)
 
 @pytest.mark.skipif(not has_podman, reason="missing podman")
-def test_run_fremake_container_build_fail():
+def test_run_fremake_container_build_fail(monkeypatch, tmp_path):
     ''' check createContainer script would fail and exit if one step failed (incorrect Dockerfile name)'''
-    if Path(f"{currPath}/createContainer.sh").exists():
-        os.remove(f"{currPath}/createContainer.sh")
+    monkeypatch.chdir(tmp_path)
+    if Path("createContainer.sh").exists():
+        os.remove("createContainer.sh")
 
     # Create the createContainer.sh script but do not run
     run_fremake_script.fremake_run(YAMLPATH, CONTAINER_PLATFORM, TARGET,
         nparallel=1, makejobs=1, gitjobs=1, no_parallel_checkout=True,
         no_format_transfer=False, execute=False, verbose=VERBOSE)
-    assert Path(f"{currPath}/createContainer.sh").exists()
+    assert Path("createContainer.sh").exists()
 
     # Alter script to fail
     new_script = []
-    with open(Path(f"{currPath}/createContainer.sh"), "r") as f:
+    with open(Path("createContainer.sh"), "r") as f:
         lines = f.readlines()
         for line in lines:
             new_script.append(line.replace("Dockerfile", "Dockerfile-wrong"))
 
-    with open(Path(f"{currPath}/createContainer.sh"), "w") as f2:
+    with open(Path("createContainer.sh"), "w") as f2:
         f2.writelines(new_script)
 
     # Run altered script and compare error
-    run = subprocess.run(Path(f"{currPath}/createContainer.sh"), capture_output=True, check=False)
+    run = subprocess.run(Path("createContainer.sh"), capture_output=True, check=False)
     stderr = run.stderr
 
     #Check that the incorrect line specifically prints in the stderr

--- a/fre/make/tests/test_create_dockerfile.py
+++ b/fre/make/tests/test_create_dockerfile.py
@@ -12,10 +12,13 @@ from fre.make import create_docker_script
 
 runner=CliRunner()
 
+# Compute repo root
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+
 # command options
-YAMLDIR = "fre/make/tests/null_example"
+YAMLDIR = os.path.join(repo_root, "fre/make/tests/null_example")
 YAMLFILE = "null_model.yaml"
-YAMLPATH = f"{YAMLDIR}/{YAMLFILE}"
+YAMLPATH = os.path.join(YAMLDIR, YAMLFILE)
 PLATFORM = ["hpcme.2023"]
 TARGET = ["debug"]
 BADOPT = ["foo"]
@@ -72,49 +75,59 @@ def test_bad_yamlpath_option():
     	execute=False, no_format_transfer=False)
 
 
-def test_no_op_platform():
+@pytest.fixture(scope="session")
+def session_tmp(tmp_path_factory):
+    return tmp_path_factory.mktemp("fre_make_test")
+
+def test_no_op_platform(monkeypatch, session_tmp):
     """
     Test create-dockerfile will do nothing if non-container platform is given
     """
-    if Path(os.getcwd()+"/tmp").exists():
-        rmtree(os.getcwd()+"/tmp") # clear out any past runs
+    monkeypatch.chdir(session_tmp)
+    if Path("tmp").exists():
+        rmtree("tmp") # clear out any past runs
     create_docker_script.dockerfile_create(YAMLPATH, ["ci.gnu"], TARGET,
     	execute=False, no_format_transfer=False)
-    assert not Path(os.getcwd()+"/tmp").exists()
+    assert not Path("tmp").exists()
 
 # tests container build script/makefile/dockerfile creation
-def test_create_dockerfile():
+def test_create_dockerfile(monkeypatch, session_tmp):
     """
     Run create-dockerfile with options for containerized build
     """
+    monkeypatch.chdir(session_tmp)
     create_docker_script.dockerfile_create(YAMLPATH, PLATFORM, TARGET,
     	execute=False, no_format_transfer=False)
 
-def test_container_dir_creation():
+def test_container_dir_creation(monkeypatch, session_tmp):
     """
     Check directories are created
     """
+    monkeypatch.chdir(session_tmp)
     assert Path(f"./tmp/{PLATFORM[0]}").exists()
 
-def test_container_build_script_creation():
+def test_container_build_script_creation(monkeypatch, session_tmp):
     """
     Checks container build script creation from previous test
     """
+    monkeypatch.chdir(session_tmp)
     assert Path("createContainer.sh").exists()
 
-def test_runscript_creation():
+def test_runscript_creation(monkeypatch, session_tmp):
     """ 
     Checks (internal) container run script creation from previous test
     """
+    monkeypatch.chdir(session_tmp)
     assert Path(f"tmp/{PLATFORM[0]}/execrunscript.sh").exists()
 
-def test_dockerfile_creation():
+def test_dockerfile_creation(monkeypatch, session_tmp):
     """
     Checks dockerfile creation from previous test
     """
+    monkeypatch.chdir(session_tmp)
     assert Path("Dockerfile").exists()
 
-def test_dockerfile_contents():
+def test_dockerfile_contents(monkeypatch, session_tmp):
     """
     Checks dockerfile contents from previous test
     """
@@ -134,11 +147,12 @@ def test_dockerfile_contents():
     line = copy_lines[2].strip().split()
     assert line == ["COPY", f"tmp/{PLATFORM[0]}/execrunscript.sh", f"{MODEL_ROOT}/{EXPERIMENT}/exec/execrunscript.sh"]
 
-def test_build_script_contents():
+def test_build_script_contents(monkeypatch, session_tmp):
     """
     Checks container build script contents from previous test. 
     Specifically - testing the volume mount is added correctly. 
     """
+    monkeypatch.chdir(session_tmp)
     # Open container build script
     with open('createContainer.sh', 'r') as f:
         lines = f.readlines()

--- a/fre/make/tests/test_run_fremake.py
+++ b/fre/make/tests/test_run_fremake.py
@@ -15,10 +15,13 @@ from fre.make import run_fremake_script
 
 runner=CliRunner()
 
+# Compute repo root
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+
 # command options
-YAMLDIR = "fre/make/tests/null_example"
+YAMLDIR = os.path.join(repo_root, "fre/make/tests/null_example")
 YAMLFILE = "null_model.yaml"
-YAMLPATH = f"{YAMLDIR}/{YAMLFILE}"
+YAMLPATH = os.path.join(YAMLDIR, YAMLFILE)
 PLATFORM = [ "ci.gnu" ]
 CONTAINER_PLATFORM = ["hpcme.2023"]
 CONTAINER_PLAT2 = ["con.twostep"]
@@ -30,13 +33,9 @@ VERBOSE = False
 # possible targets
 targets = ["debug", "prod", "repro", "debug-openmp", "prod-openmp", "repro-openmp"]
 
-# set up some paths for the tests
-SERIAL_TEST_PATH="fre/make/tests/test_run_fremake_serial"
-MULTIJOB_TEST_PATH="fre/make/tests/test_run_fremake_multijob"
-MULTITARGET_TEST_PATH="fre/make/tests/test_run_fremake_multitarget"
-Path(SERIAL_TEST_PATH).mkdir(parents=True,exist_ok=True)
-Path(MULTIJOB_TEST_PATH).mkdir(parents=True,exist_ok=True)
-Path(MULTITARGET_TEST_PATH).mkdir(parents=True,exist_ok=True)
+@pytest.fixture(scope="session")
+def session_tmp(tmp_path_factory):
+    return tmp_path_factory.mktemp("fre_make_test")
 
 ##def fremake_run(yamlfile,platform,target,parallel,jobs,no_parallel_checkout,execute,verbose):
 
@@ -189,21 +188,20 @@ def test_run_fremake_dockerfile_creation_container_2stage():
     ''' checks dockerfile creation from previous test '''
     assert Path("Dockerfile").exists()
 
-def test_run_fremake_checkout_script_creation_container_2stage():
+def test_run_fremake_checkout_script_creation_container_2stage(monkeypatch, session_tmp):
     ''' checks checkout script creation from previous test '''
-    cwd = os.getcwd()
-    print(f"checking path: {cwd}/tmp/{CONTAINER_PLAT2[0]}/checkout.sh")
-    assert Path(f"{cwd}/tmp/{CONTAINER_PLAT2[0]}/checkout.sh").exists()
+    monkeypatch.chdir(session_tmp)
+    assert Path(f"tmp/{CONTAINER_PLAT2[0]}/checkout.sh").exists()
 
-def test_run_fremake_makefile_creation_container_2stage():
+def test_run_fremake_makefile_creation_container_2stage(monkeypatch, session_tmp):
     ''' checks makefile creation from previous test '''
-    cwd = os.getcwd()
-    assert Path(f"{cwd}/tmp/{CONTAINER_PLAT2[0]}/Makefile").exists()
+    monkeypatch.chdir(session_tmp)
+    assert Path(f"tmp/{CONTAINER_PLAT2[0]}/Makefile").exists()
 
-def test_run_fremake_run_script_creation_container_2stage():
+def test_run_fremake_run_script_creation_container_2stage(monkeypatch, session_tmp):
     ''' checks (internal) container run script creation from previous test '''
-    cwd = os.getcwd()
-    assert Path(f"{cwd}/tmp/{CONTAINER_PLAT2[0]}/execrunscript.sh").exists()
+    monkeypatch.chdir(session_tmp)
+    assert Path(f"tmp/{CONTAINER_PLAT2[0]}/execrunscript.sh").exists()
 
 # tests for builds with multiple targets
 


### PR DESCRIPTION
Make YAMLPATH absolute, replace getcwd with tmp_path, use session tmp for interdependent tests. Resolves issue #738.

## Describe your changes
Asked copilot to fix #738 using pytest fixtures to ensure a temporary directory is always available.

## Issue ticket number and link (if applicable)
#738 

## Checklist before requesting a review

- [ ] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module

*Note: If you are a code maintainer updating the tag or releasing a new fre-cli version, please use the `release_procedure.md` template. To quickly use this template, open a new pull request, choose your branch, and add `?template=release_procedure.md` to the end of the url.*
