### PR TITLE
Fixes sphinx documentation build warnings

### DIFF
--- a/fre/cmor/tests/test_cmor_finder_make_simple_varlist.py
+++ b/fre/cmor/tests/test_cmor_finder_make_simple_varlist.py
@@ -190,9 +190,9 @@ def test_make_simple_varlist_mip_table_filter(tmp_path):
 # ---- IndexError on datetime extraction (monkeypatched) ----
 def test_make_simple_varlist_index_error_on_datetime(tmp_path):
     """
-    When os.path.basename(one_file).split('.')[-3] raises IndexError
+    When ``os.path.basename(one_file).split('.')[-3]`` raises IndexError
     (e.g. a file with fewer than 3 dot-segments sneaks in), the function
-    should catch it, set one_datetime = None, and fall back to the '*nc'
+    should catch it, set one_datetime = None, and fall back to the ``'*nc'``
     search pattern.
     Covers the except IndexError branch and the one_datetime is None path.
     """

--- a/fre/make/create_checkout_script.py
+++ b/fre/make/create_checkout_script.py
@@ -29,7 +29,7 @@ def baremetal_checkout_write(model_yaml: yamlfre.freyaml, src_dir: str, jobs: st
     
       - Extract compilation specifications from the parsed YAML configuration
       - Generate a checkout script to the source directory. The source directory is
-      defined within the 'modelRoot' variable in the "platforms" section of the combined YAML
+        defined within the 'modelRoot' variable in the "platforms" section of the combined YAML
       
 
     :param model_yaml: "freyaml" class object containing a parsed and validated yaml dictionary 
@@ -63,7 +63,7 @@ def container_checkout_write(model_yaml: yamlfre.freyaml, src_dir: str, tmp_dir:
     
       - Extract compilation specifications from the parsed YAML configuration
       - Generate a checkout script in a local ./tmp directory, where it will later be
-      copied to the directory of the container image filesystem for execution
+        copied to the directory of the container image filesystem for execution
 
     :param model_yaml: "freyaml" class object containing a parsed and validated yaml dictionary 
                        containing the "compile" specification

--- a/fre/pp/rename_split_script.py
+++ b/fre/pp/rename_split_script.py
@@ -91,10 +91,10 @@ def get_duration_from_two_dates(date1: cftime.datetime, date2: cftime.datetime) 
 def rename_file(input_file: str, diag_manifest: tuple[str, ...] | str | None = ()) -> Path:
     """
     Accept an input netCDF file that is the result of split-netcdf, e.g.
-        00010101.atmos_daily.tile1.temp.nc
+    ``00010101.atmos_daily.tile1.temp.nc``
     and output a directory and filename that identifies its frequency, interval,
     and beginning and ending dates, e.g.
-        P1D/P6M/atmos_daily.00010101-00010630.temp.tile1.nc
+    ``P1D/P6M/atmos_daily.00010101-0001063.temp.tile1.nc``
 
     :param input_file: Path to the input NetCDF file.
     :type input_file: str

--- a/fre/pp/tests/test_rename_split_to_pp.py
+++ b/fre/pp/tests/test_rename_split_to_pp.py
@@ -157,35 +157,47 @@ def test_rename_split_to_pp_multiply_setup():
                           ])
 def test_rename_split_to_pp_run(hist_source, do_regrid, og_suffix):
     '''
-    Tests the running of rename-split-to-pp, which takes 3 input args:
-      hist_source: source of the history data, used to build input and output paths
-      do_regrid: whether to do regridding, boolean, changes dir structure
-      og_suffix: the frequency suffix that rename-split-to-pp should be adding to
-         the output data dir structure
-    rename-split-to-pp takes 4 arguments, which are set as env variables:
-      inputDir (inputDir)  - location of your input files, output from split-netcdf
-      outputDir (outputDir) - location to which to write your output files
-      component (history_source) - VERY BADLY NAMED. What split-netcdf is calling the hist_source after the rewrite.
-      use_subdirs (do_regrid) - either set to 1 or unset. 1 is used for the regridding case.
-        * no longer set to 1 or unset, set to "True" or "False". Makes the if checks
-        more sensitive, but makes the setup/teardown of unsetting env variables easier.
+    Tests the running of ``rename-split-to-pp``, which takes 3 input args:
+
+    :param hist_source: source of the history data, used to build input and output paths
+    :param do_regrid: whether to do regridding, boolean, changes dir structure
+    :param og_suffix: the frequency suffix that ``rename-split-to-pp`` should be adding to
+                      the output data dir structure
+
+    ``rename-split-to-pp`` takes 4 arguments, which are set as env variables:
+
+    :inputDir: (inputDir) location of your input files, output from split-netcdf
+    :outputDir: (outputDir) location to which to write your output files
+    :component: (history_source) VERY BADLY NAMED. What split-netcdf is calling the hist_source after the rewrite.
+    :use_subdirs: (do_regrid) either set to 1 or unset. 1 is used for the regridding case.
+
+                  - no longer set to 1 or unset, set to "True" or "False". Makes the if checks
+                    more sensitive, but makes the setup/teardown of unsetting env variables easier.
+
     These tests operate under 4 frequencies with regridding/no regridding cases:
+
       - success:
-        - daily regrid/native, multiple tiles
-        - monthly regird/native, multiple tiles (currently failing because of metadata)
-        - annual regrid/native
-        - static regrid/no regrid
+
+         - daily regrid/native, multiple tiles
+         - monthly regird/native, multiple tiles (currently failing because of metadata)
+         - annual regrid/native
+         - static regrid/no regrid
+
       - failure:
-        - files in input don't match naming convention, raises error TBD
-        - no files in input dir, raises error TBD
-    For the moment, rename=split-to-pp isn't doing any rewriting of files -
+
+         - files in input don't match naming convention, raises error TBD
+         - no files in input dir, raises error TBD
+
+    For the moment, ``rename-split-to-pp`` isn't doing any rewriting of files -
     it's copying files to new locations and verifying that they have the 
     right number of timesteps. 
     I've included hooks for functions that check on data + metadata, but we
     really don't need them yet.
+
     TODO:
-      - when this is ported to python, the xfail tests should check for the python error that gets raised - 
-      but until that point, not a whole lot of point in checking on a raised exception here
+
+      - When this is ported to python, the ``xfail`` tests should check for the python error that gets raised, 
+        but until that point, not a whole lot of point in checking on a raised exception here
     '''
     # if not os.path.isdir(outputDir):
     #   os.mkdir(outputDir)

--- a/fre/pp/tests/test_rename_split_to_pp.py
+++ b/fre/pp/tests/test_rename_split_to_pp.py
@@ -179,7 +179,7 @@ def test_rename_split_to_pp_run(hist_source, do_regrid, og_suffix):
       - success:
 
          - daily regrid/native, multiple tiles
-         - monthly regird/native, multiple tiles (currently failing because of metadata)
+         - monthly regrid/native, multiple tiles (currently failing because of metadata)
          - annual regrid/native
          - static regrid/no regrid
 


### PR DESCRIPTION
## Describe your changes
A few recent PRs contained documentation updates.  Sphinx/rST formatting errors caused documentation to be generated with bad formatting - I noticed this because of warnings in the readthedocs builds.  This is a PR with simple changes to files relates to formatting of docstrings.  *No code changes, only docstrings.*

Main things to point out:
- sphinx likes blank lines before and after bulleted lists
- If your line is too long and you want to continue on the next line, it needs to align with the first character of the line above 

e.g. 
```
"""
this is a list

- this is a very very very very very very long
  line in that list
- this is a short line

  - this is a nested list (which I precede with a blank line)
 
Lists can be identified with a ``-`` or a ``*`` and if you do not enclose an asterix in double back ticks,
it will try to bold text and give an error that there is no closing asterix to indicate where the formatting
ends
"""
 ```

## Issue ticket number and link (if applicable)

## Checklist before requesting a review

- [ ] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module

*Note: If you are a code maintainer updating the tag or releasing a new fre-cli version, please use the `release_procedure.md` template. To quickly use this template, open a new pull request, choose your branch, and add `?template=release_procedure.md` to the end of the url.*
