### PR TITLE
fix: propagate logging verbosity to external packages

### DIFF
--- a/fre/fre.py
+++ b/fre/fre.py
@@ -59,9 +59,9 @@ def fre(verbose = 0, quiet = False, log_file = None):
     if quiet:
         log_level = logging.ERROR # least verbose
 
-    base_fre_logger=fre_logger.parent
-    base_fre_logger.setLevel(level = log_level)
-    fre_logger.debug('root fre_logger level set')
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level = log_level)
+    fre_logger.debug('root logger level set')
 
     # check if log_file arg was used
     if log_file is not None:
@@ -74,8 +74,8 @@ def fre(verbose = 0, quiet = False, log_file = None):
         fre_log_file_formatter=logging.Formatter(fmt=FORMAT)
         fre_file_handler.setFormatter(fre_log_file_formatter)
 
-        base_fre_logger.addHandler(fre_file_handler)
+        root_logger.addHandler(fre_file_handler)
         # first message that will appear in the log file if used
-        fre_logger.info('fre_file_handler added to base_fre_logger')
+        fre_logger.info('fre_file_handler added to root_logger')
 
     fre_logger.debug('click entry-point function call done.')


### PR DESCRIPTION
The fre catalog build command uses external Python code from catalogbuilder that also uses standard logging, but -vv (DEBUG) and -v (INFO) flags did not affect logs from external code.

Root cause: logging configuration was setting level only on fre logger parent, affecting only fre package loggers. External packages use their own loggers inheriting from root logger at WARNING level.

Solution: set log_level on root logger directly. Now all loggers including external ones respect verbosity flags passed via click.

## Describe your changes

## Issue ticket number and link (if applicable)
#805 

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module

*Note: If you are a code maintainer updating the tag or releasing a new fre-cli version, please use the `release_procedure.md` template. To quickly use this template, open a new pull request, choose your branch, and add `?template=release_procedure.md` to the end of the url.*
