### PR TITLE
Manually update fre-cli's package version to 2026.01.alpha2

### DIFF
--- a/fre/__init__.py
+++ b/fre/__init__.py
@@ -4,7 +4,7 @@ module init file for fre. sets the version attribute, and sets up a fre_logger
 
 import logging
 import os
-version = os.getenv("GIT_DESCRIBE_TAG", "2026.01.alpha1")
+version = os.getenv("GIT_DESCRIBE_TAG", "2026.01.alpha2")
 __version__ = version
 
 fre_logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Describe your changes
The github action should do it, but it didn't work so @singhd789 manually deployed. (All the more need for the action, lol)

Note: I hand-fixed the deployed fre/2026.01.alpha so we don't have to redeploy this.

## Issue ticket number and link (if applicable)
Fixes #XXX (replace XXX with the issue number and GitHub will autolink the PR to the issue)
## Checklist before requesting a review

- [ ] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module

*Note: If you are a code maintainer updating the tag or releasing a new fre-cli version, please use the `release_procedure.md` template. To quickly use this template, open a new pull request, choose your branch, and add `?template=release_procedure.md` to the end of the url.*
