### PR TITLE
Rename src dir instead of removing

### DIFF
--- a/fre/make/create_checkout_script.py
+++ b/fre/make/create_checkout_script.py
@@ -103,8 +103,9 @@ def checkout_create(yamlfile: str, platform: tuple, target: tuple,
     :type njobs: int
     :param execute: If True, run checkout.sh
     :type execute: bool
-    :param force_checkout: If True, for bare-metal: add timestamp to source directory and create new checkout script,
-                           for container: overwrite locally existing checkout script
+    :param force_checkout: If True, for bare-metal build: add timestamp to source directory and create a new checkout script
+                           If True, for container build: overwrite locally existing checkout script before COPY-ing to the 
+                           container image filesystem
     :type force_checkout: bool
 
     :raises ValueError:

--- a/fre/make/create_checkout_script.py
+++ b/fre/make/create_checkout_script.py
@@ -11,8 +11,9 @@ Note, a bare-metal build defaults to a parallel checkout.
 A container build defaults to a non-parallel checkout.
 
 '''
-
-import os
+import shutil
+from pathlib import Path
+from datetime import datetime
 import subprocess
 import logging
 from typing import Optional
@@ -49,8 +50,8 @@ def baremetal_checkout_write(model_yaml: yamlfre.freyaml, src_dir: str, jobs: st
     fre_checkout.finish(model_yaml.compile.getCompileYaml(), parallel_cmd)
 
     # Make checkout script executable (rwxr--r--)
-    checkout_path = os.path.join(src_dir, "checkout.sh")
-    os.chmod(checkout_path, 0o744)
+    checkout_path = Path(f"{src_dir}/checkout.sh")
+    checkout_path.chmod(0o744)
     fre_logger.info("Checkout script created in %s", checkout_path)
 
     if execute:
@@ -159,29 +160,36 @@ def checkout_create(yamlfile: str, platform: tuple, target: tuple,
         if not platform_info["container"]:
             src_dir = f'{platform_info["modelRoot"]}/{fremake_yaml["experiment"]}/src'
 
-            if not os.path.exists(src_dir):
-                os.makedirs(src_dir, exist_ok=True)
+            if not Path(src_dir).exists():
+                Path(src_dir).mkdir(parents=True, exist_ok=True)
 
-            checkout_sh_path = os.path.join(src_dir, "checkout.sh")
+            checkout_sh_path = Path(f"{src_dir}/checkout.sh")
 
-            if not os.path.exists(checkout_sh_path):
+            if not checkout_sh_path.exists():
                 baremetal_checkout_write(model_yaml, src_dir, jobs_str, parallel_cmd, execute)
 
-            elif os.path.exists(checkout_sh_path) and force_checkout:
+            elif checkout_sh_path.exists() and force_checkout:
                 fre_logger.info("Checkout script PREVIOUSLY created in %s", checkout_sh_path)
-                fre_logger.info("*** REMOVING CHECKOUT SCRIPT ***")
 
-                os.remove(checkout_sh_path)
+                # New folder name
+                timestamp = datetime.now().strftime("%Y%m%d.%H%M%S")
+                new_src_dirname = f"{Path(src_dir).name}.{timestamp}"
+                # Create path and rename folder in same directory 
+                new_src_dir =  Path(src_dir).with_name(new_src_dirname)
+                Path(src_dir).rename(new_src_dir)
+                fre_logger.info(f" *** SRC DIR RENAMED: {new_src_dir} *** ")
+
+                fre_logger.info(" *** RE-CREATING CHECKOUT *** ")
                 baremetal_checkout_write(model_yaml, src_dir, jobs_str, parallel_cmd, execute)
 
-            elif os.path.exists(checkout_sh_path) and not force_checkout:
-                fre_logger.info("Checkout script PREVIOUSLY created in %s", checkout_sh_path)
+            elif Path(checkout_sh_path).exists() and not force_checkout:
+                fre_logger.info("Checkout script PREVIOUSLY created here: %s", checkout_sh_path)
                 if execute:
                     try:
                         subprocess.run(args=[checkout_sh_path], check=True)
                     except Exception as exc:
                         raise OSError(f"\nError executing checkout script: {checkout_sh_path}.",
-                                      f"\nTry removing test folder: {platform_info['modelRoot']}\n") from exc
+                                      f"\nTry removing test folder: {platform_info['modelRoot']} or specifying --force-checkout\n") from exc
                 else:
                     return
 
@@ -192,17 +200,17 @@ def checkout_create(yamlfile: str, platform: tuple, target: tuple,
             tmp_dir = f"tmp/{platform_name}"
             container_pc = ""
 
-            os.makedirs(tmp_dir, exist_ok=True)
-            tmp_checkout_path = os.path.join(tmp_dir, "checkout.sh")
+            Path(tmp_dir).mkdir(parents=True, exist_ok=True)
+            tmp_checkout_path = Path(f"{tmp_dir}/checkout.sh")
 
-            if not os.path.exists(tmp_checkout_path):
+            if not Path(tmp_checkout_path).exists():
                 container_checkout_write(model_yaml, src_dir, tmp_dir, jobs_str, container_pc)
 
-            elif os.path.exists(tmp_checkout_path) and force_checkout:
+            elif Path(tmp_checkout_path).exists() and force_checkout:
                 fre_logger.info("Checkout script PREVIOUSLY created in %s", tmp_checkout_path)
                 fre_logger.info("*** REMOVING CHECKOUT SCRIPT ***")
-                os.remove(tmp_checkout_path)
+                shutil.rmtree(tmp_dir)
                 container_checkout_write(model_yaml, src_dir, tmp_dir, jobs_str, container_pc)
 
-            elif os.path.exists(tmp_checkout_path) and not force_checkout:
+            elif Path(tmp_checkout_path).exists() and not force_checkout:
                 fre_logger.info("Checkout script PREVIOUSLY created in %s", tmp_checkout_path)

--- a/fre/make/create_checkout_script.py
+++ b/fre/make/create_checkout_script.py
@@ -103,7 +103,8 @@ def checkout_create(yamlfile: str, platform: tuple, target: tuple,
     :type njobs: int
     :param execute: If True, run checkout.sh
     :type execute: bool
-    :param force_checkout: If True, overwrite locally existing checkout script and source code
+    :param force_checkout: If True, for bare-metal: add timestamp to source directory and create new checkout script,
+                           for container: overwrite locally existing checkout script
     :type force_checkout: bool
 
     :raises ValueError:
@@ -207,10 +208,10 @@ def checkout_create(yamlfile: str, platform: tuple, target: tuple,
             if not Path(tmp_checkout_path).exists():
                 container_checkout_write(model_yaml, src_dir, tmp_dir, jobs_str, container_pc)
 
-            elif Path(tmp_checkout_path).exists() and force_checkout:
+            elif tmp_checkout_path.exists() and force_checkout:
                 fre_logger.info("Checkout script PREVIOUSLY created in %s", tmp_checkout_path)
                 fre_logger.info("*** REMOVING CHECKOUT SCRIPT ***")
-                shutil.rmtree(tmp_dir)
+                tmp_checkout_path.unlink()
                 container_checkout_write(model_yaml, src_dir, tmp_dir, jobs_str, container_pc)
 
             elif Path(tmp_checkout_path).exists() and not force_checkout:

--- a/fre/make/create_checkout_script.py
+++ b/fre/make/create_checkout_script.py
@@ -194,8 +194,8 @@ def checkout_create(yamlfile: str, platform: tuple, target: tuple,
                         subprocess.run(args=[checkout_sh_path], check=True)
                     except Exception as exc:
                         raise OSError(f"\nError executing checkout script: {checkout_sh_path}.",
-                                      f"\nTry removing test folder: {platform_info['modelRoot']}"
-                                       "or  specifying --force-checkout\n") from exc
+                                      "\nSRC DIR might exist already. Try removing test folder: "
+                                      f"{platform_info['modelRoot']} or  specifying --force-checkout\n") from exc
                 else:
                     return
 

--- a/fre/make/create_checkout_script.py
+++ b/fre/make/create_checkout_script.py
@@ -23,7 +23,7 @@ from .gfdlfremake import varsfre, yamlfre, checkout, targetfre
 # set up logging
 fre_logger = logging.getLogger(__name__)
 
-def baremetal_checkout_write(model_yaml: yamlfre.freyaml, src_dir: str, jobs: str, 
+def baremetal_checkout_write(model_yaml: yamlfre.freyaml, src_dir: str, jobs: str,
                              parallel_cmd: str, execute: bool):
     """
     This function baremetal_checkout_write is called by checkout_create in order to
@@ -140,7 +140,7 @@ def checkout_create(yamlfile: str, platform: tuple, target: tuple,
 
     # Validate the targets
     for t in target:
-      valid_t = targetfre.fretarget(t)
+        valid_t = targetfre.fretarget(t)
 
     fre_logger.setLevel(level=logging.INFO)
 
@@ -174,10 +174,10 @@ def checkout_create(yamlfile: str, platform: tuple, target: tuple,
                 # New folder name
                 timestamp = datetime.now().strftime("%Y%m%d.%H%M%S")
                 new_src_dirname = f"{Path(src_dir).name}.{timestamp}"
-                # Create path and rename folder in same directory 
+                # Create path and rename folder in same directory
                 new_src_dir =  Path(src_dir).with_name(new_src_dirname)
                 Path(src_dir).rename(new_src_dir)
-                fre_logger.info(f" *** SRC DIR RENAMED: {new_src_dir} *** ")
+                fre_logger.info(" *** SRC DIR RENAMED: %s *** ", new_src_dir)
 
                 fre_logger.info(" *** RE-CREATING CHECKOUT *** ")
                 baremetal_checkout_write(model_yaml, src_dir, jobs_str, parallel_cmd, execute)
@@ -189,7 +189,8 @@ def checkout_create(yamlfile: str, platform: tuple, target: tuple,
                         subprocess.run(args=[checkout_sh_path], check=True)
                     except Exception as exc:
                         raise OSError(f"\nError executing checkout script: {checkout_sh_path}.",
-                                      f"\nTry removing test folder: {platform_info['modelRoot']} or specifying --force-checkout\n") from exc
+                                      f"\nTry removing test folder: {platform_info['modelRoot']}"
+                                       "or  specifying --force-checkout\n") from exc
                 else:
                     return
 

--- a/fre/make/create_checkout_script.py
+++ b/fre/make/create_checkout_script.py
@@ -185,6 +185,10 @@ def checkout_create(yamlfile: str, platform: tuple, target: tuple,
 
             elif Path(checkout_sh_path).exists() and not force_checkout:
                 fre_logger.info("Checkout script PREVIOUSLY created here: %s", checkout_sh_path)
+                fre_logger.warning("If editing source code after creating and running the checkout script for the "
+                                   "bare-metal build, continue to follow each fre make subtool individually ('makefile', "
+                                   "'compile-script' or 'dockerfile') to avoid conflicting 'existing checkout script' "
+                                   "errors (advise against using fre make all)")
                 if execute:
                     try:
                         subprocess.run(args=[checkout_sh_path], check=True)

--- a/fre/make/create_docker_script.py
+++ b/fre/make/create_docker_script.py
@@ -120,7 +120,7 @@ def dockerfile_create(yamlfile: str, platform: tuple[str], target: tuple[str],
             fre_logger.setLevel(logging.INFO)
             fre_logger.info("tmpDir created in " + currDir + "/tmp")
             fre_logger.info("Dockerfile created in " + currDir)
-            fre_logger.info("Container build script created at "+dockerBuild.userScriptPath)
+            fre_logger.info("Container build script created in "+dockerBuild.userScriptPath)
             fre_logger.setLevel(former_log_level)
 
             # run the script if option is given

--- a/fre/make/run_fremake_script.py
+++ b/fre/make/run_fremake_script.py
@@ -99,6 +99,7 @@ def fremake_run(yamlfile:str, platform:str, target:str,
         if not platform_info["container"]:
             bm_platforms = bm_platforms + (platform_name,)
 
+            # If force-checkout is passed, re-create the compile script
             # This will eventually just turn into if force_checkout, force_compile = True (once force_compile exists)
             if force_checkout:
                 for target_name in tlist:

--- a/fre/make/run_fremake_script.py
+++ b/fre/make/run_fremake_script.py
@@ -61,7 +61,7 @@ def fremake_run(yamlfile:str, platform:str, target:str,
     # Define variables
     name = yamlfile.split(".")[0]
     plist = platform
-#    tlist = target
+    tlist = target
 
     # Combine model, compile, and platform yamls
     full_combined = cy.consolidate_yamls(yamlfile=yamlfile,
@@ -76,7 +76,7 @@ def fremake_run(yamlfile:str, platform:str, target:str,
 
     ## Open the yaml file, validate the yaml, and parse as fremake_yaml
     model_yaml = yamlfre.freyaml(full_combined,fre_vars)
-#    fremake_yaml = model_yaml.getCompileYaml()
+    fremake_yaml = model_yaml.getCompileYaml()
 
     #checkout
     fre_logger.info("Running fre make: calling checkout_create")
@@ -99,28 +99,16 @@ def fremake_run(yamlfile:str, platform:str, target:str,
         if not platform_info["container"]:
             bm_platforms = bm_platforms + (platform_name,)
 
-##mught not be needed
-#            #####
-#            # This will eventually just turn into if force_checkout, force_compile = True (once force_compile exists)
-#            if force_checkout:
-#                for target_name in tlist:
-#                    compile_script = Path(f'{platform_info["modelRoot"]}/{fremake_yaml["experiment"]}/' + \
-#                                          f'{platform_name}-{target_name}/exec/compile.sh')
-#                    if compile_script.exists():
-#                        fre_logger.warning("Running fre make: (from force-checkout) removing previously generated compile script")
-#                        compile_script.unlink()
-#            #####
+            # This will eventually just turn into if force_checkout, force_compile = True (once force_compile exists)
+            if force_checkout:
+                for target_name in tlist:
+                    compile_script = Path(f'{platform_info["modelRoot"]}/{fremake_yaml["experiment"]}/' + \
+                                          f'{platform_name}-{target_name}/exec/compile.sh')
+                    if compile_script.exists():
+                        fre_logger.warning("Running fre make: (from force-checkout) removing previously generated compile script")
+                        compile_script.unlink()
         else:
             container_platforms = container_platforms + (platform_name,)
-##might not be needed
-#            #####
-#            # This will eventually just turn into if force_checkout, force_dockerfile = True (once force_dockerfile exists)
-#            if force_checkout:
-#                dockerfile = Path(f"{Path.cwd()}/Dockerfile")
-#                if dockerfile.exists():
-#                    fre_logger.warning("Running fre make: (from force-checkout) removing previously generated Dockerfile")
-#                    dockerfile.unlink()
-#            #####
 
     if bm_platforms:
         #compile

--- a/fre/make/run_fremake_script.py
+++ b/fre/make/run_fremake_script.py
@@ -110,6 +110,15 @@ def fremake_run(yamlfile:str, platform:str, target:str,
                         compile_script.unlink()
         else:
             container_platforms = container_platforms + (platform_name,)
+            # If force-checkout is passed, re-create the Dockerfile
+            # If the Dockerfile is not removed after force-checkout, it uses the cache (with the old checkout)
+            # This will eventually just turn into if force_checkout, force_dockerfile = True (once force_compile exists)
+            if force_checkout:
+                # remove Dockerfile
+                dockerfile = Path(f"{Path.cwd()}/Dockerfile")
+                if Dockerfile.exists():
+                    fre_logger.warning("Running fre make: (from force-checkout) removing previously generated Dockerfile")
+                    dockerfile.unlink()
 
     if bm_platforms:
         #compile

--- a/fre/make/run_fremake_script.py
+++ b/fre/make/run_fremake_script.py
@@ -13,7 +13,7 @@ from fre.make.create_checkout_script import checkout_create
 from fre.make.create_makefile_script import makefile_create
 from fre.make.create_compile_script import compile_create
 from fre.make.create_docker_script import dockerfile_create
-from .gfdlfremake import (varsfre, yamlfre, targetfre)
+from .gfdlfremake import (varsfre, yamlfre)
 
 fre_logger = logging.getLogger(__name__)
 

--- a/fre/make/run_fremake_script.py
+++ b/fre/make/run_fremake_script.py
@@ -61,7 +61,7 @@ def fremake_run(yamlfile:str, platform:str, target:str,
     # Define variables
     name = yamlfile.split(".")[0]
     plist = platform
-    tlist = target
+#    tlist = target
 
     # Combine model, compile, and platform yamls
     full_combined = cy.consolidate_yamls(yamlfile=yamlfile,
@@ -76,7 +76,7 @@ def fremake_run(yamlfile:str, platform:str, target:str,
 
     ## Open the yaml file, validate the yaml, and parse as fremake_yaml
     model_yaml = yamlfre.freyaml(full_combined,fre_vars)
-    fremake_yaml = model_yaml.getCompileYaml()
+#    fremake_yaml = model_yaml.getCompileYaml()
 
     #checkout
     fre_logger.info("Running fre make: calling checkout_create")
@@ -99,26 +99,28 @@ def fremake_run(yamlfile:str, platform:str, target:str,
         if not platform_info["container"]:
             bm_platforms = bm_platforms + (platform_name,)
 
-            #####
-            # This will eventually just turn into if force_checkout, force_compile = True (once force_compile exists)
-            if force_checkout:
-                for target_name in tlist:
-                    compile_script = Path(f'{platform_info["modelRoot"]}/{fremake_yaml["experiment"]}/' + \
-                                          f'{platform_name}-{target_name}/exec/compile.sh')
-                    if compile_script.exists():
-                        fre_logger.warning("Running fre make: (from force-checkout) removing previously generated compile script")
-                        compile_script.unlink()
-            #####
+##mught not be needed
+#            #####
+#            # This will eventually just turn into if force_checkout, force_compile = True (once force_compile exists)
+#            if force_checkout:
+#                for target_name in tlist:
+#                    compile_script = Path(f'{platform_info["modelRoot"]}/{fremake_yaml["experiment"]}/' + \
+#                                          f'{platform_name}-{target_name}/exec/compile.sh')
+#                    if compile_script.exists():
+#                        fre_logger.warning("Running fre make: (from force-checkout) removing previously generated compile script")
+#                        compile_script.unlink()
+#            #####
         else:
             container_platforms = container_platforms + (platform_name,)
-            #####
-            # This will eventually just turn into if force_checkout, force_dockerfile = True (once force_dockerfile exists)
-            if force_checkout:
-                dockerfile = Path(f"{Path.cwd()}/Dockerfile")
-                if dockerfile.exists():
-                    fre_logger.warning("Running fre make: (from force-checkout) removing previously generated Dockerfile")
-                    dockerfile.unlink()
-            #####
+##might not be needed
+#            #####
+#            # This will eventually just turn into if force_checkout, force_dockerfile = True (once force_dockerfile exists)
+#            if force_checkout:
+#                dockerfile = Path(f"{Path.cwd()}/Dockerfile")
+#                if dockerfile.exists():
+#                    fre_logger.warning("Running fre make: (from force-checkout) removing previously generated Dockerfile")
+#                    dockerfile.unlink()
+#            #####
 
     if bm_platforms:
         #compile

--- a/fre/make/run_fremake_script.py
+++ b/fre/make/run_fremake_script.py
@@ -7,12 +7,13 @@ For a container build: Creates the checkout script and makefile, and creates and
 '''
 import logging
 from typing import Optional
+from pathlib import Path
 import fre.yamltools.combine_yamls_script as cy
 from fre.make.create_checkout_script import checkout_create
 from fre.make.create_makefile_script import makefile_create
 from fre.make.create_compile_script import compile_create
 from fre.make.create_docker_script import dockerfile_create
-from .gfdlfremake import (varsfre, yamlfre)
+from .gfdlfremake import (varsfre, yamlfre, targetfre)
 
 fre_logger = logging.getLogger(__name__)
 
@@ -60,6 +61,7 @@ def fremake_run(yamlfile:str, platform:str, target:str,
     # Define variables
     name = yamlfile.split(".")[0]
     plist = platform
+    tlist = target
 
     # Combine model, compile, and platform yamls
     full_combined = cy.consolidate_yamls(yamlfile=yamlfile,
@@ -74,6 +76,7 @@ def fremake_run(yamlfile:str, platform:str, target:str,
 
     ## Open the yaml file, validate the yaml, and parse as fremake_yaml
     model_yaml = yamlfre.freyaml(full_combined,fre_vars)
+    fremake_yaml = model_yaml.getCompileYaml()
 
     #checkout
     fre_logger.info("Running fre make: calling checkout_create")
@@ -95,8 +98,27 @@ def fremake_run(yamlfile:str, platform:str, target:str,
 
         if not platform_info["container"]:
             bm_platforms = bm_platforms + (platform_name,)
+
+            #####
+            # This will eventually just turn into if force_checkout, force_compile = True (once force_compile exists)
+            if force_checkout:
+                for target_name in tlist:
+                    compile_script = Path(f'{platform_info["modelRoot"]}/{fremake_yaml["experiment"]}/' + \
+                                          f'{platform_name}-{target_name}/exec/compile.sh')
+                    if compile_script.exists():
+                        fre_logger.warning("Running fre make: (from force-checkout) removing previously generated compile script")
+                        compile_script.unlink()
+            #####
         else:
             container_platforms = container_platforms + (platform_name,)
+            #####
+            # This will eventually just turn into if force_checkout, force_dockerfile = True (once force_dockerfile exists)
+            if force_checkout:
+                dockerfile = Path(f"{Path.cwd()}/Dockerfile")
+                if dockerfile.exists():
+                    fre_logger.warning("Running fre make: (from force-checkout) removing previously generated Dockerfile")
+                    dockerfile.unlink()
+            #####
 
     if bm_platforms:
         #compile

--- a/fre/make/run_fremake_script.py
+++ b/fre/make/run_fremake_script.py
@@ -116,7 +116,7 @@ def fremake_run(yamlfile:str, platform:str, target:str,
             if force_checkout:
                 # remove Dockerfile
                 dockerfile = Path(f"{Path.cwd()}/Dockerfile")
-                if Dockerfile.exists():
+                if dockerfile.exists():
                     fre_logger.warning("Running fre make: (from force-checkout) removing previously generated Dockerfile")
                     dockerfile.unlink()
 

--- a/fre/make/tests/test_create_checkout.py
+++ b/fre/make/tests/test_create_checkout.py
@@ -3,6 +3,8 @@ Test fre make checkout-script
 """
 from pathlib import Path
 import shutil
+import pytest
+import re
 from fre.make import create_checkout_script
 
 # Set example yaml paths, input directory
@@ -80,6 +82,28 @@ def test_checkout_execute(monkeypatch):
                 any(Path(f"{OUT}/fremake_canopy/test/null_model_full/src/FMS").iterdir()),
                 Path(f"{OUT}/fremake_canopy/test/null_model_full/src/coupler").is_dir(),
                 any(Path(f"{OUT}/fremake_canopy/test/null_model_full/src/coupler").iterdir())])
+
+def test_bm_checkout_again(caplog, monkeypatch):
+    """
+    """
+    monkeypatch.setenv("TEST_BUILD_DIR", OUT)
+
+    # Check for checkout script and for some resulting folders from previous test 
+    assert all([Path(f"{OUT}/fremake_canopy/test/null_model_full/src/checkout.sh").exists(),
+                Path(f"{OUT}/fremake_canopy/test/null_model_full/src/FMS").exists()])
+
+    # Run checkout again and check for error output
+    with pytest.raises(OSError) as excinfo: #, match = re.escape(expected_failure)):
+        create_checkout_script.checkout_create(YAMLFILE,
+                                               PLATFORM,
+                                               TARGET,
+                                               no_parallel_checkout = False,
+                                               njobs = 2,
+                                               execute = True,
+                                               force_checkout = False)
+    assert ([f"\nError executing checkout script: {OUT}/fremake_canopy/test/null_model_full/src/checkout.sh." in str(excinfo.value),
+             f"\nTry removing test folder: {OUT}/fremake_canopy/test or  specifying --force-checkout" in str(excinfo.value)])
+    
 
 def test_checkout_no_parallel_checkout(monkeypatch):
     """
@@ -210,5 +234,3 @@ def test_container_checkout_force_checkout(caplog):
     assert all([expected_line in content,
                "pids" not in content,
                "mock container checkout content" not in content])
-
-##test checkout w/o force but if it already exists

--- a/fre/make/tests/test_create_checkout.py
+++ b/fre/make/tests/test_create_checkout.py
@@ -117,7 +117,7 @@ def test_bm_checkout_force_checkout(caplog, monkeypatch):
     shutil.rmtree(f"{OUT}/fremake_canopy/test", ignore_errors=True)
 
     ## Mock checkout script with some content we can check
-    # Create come checkout script
+    # Create some checkout script
     mock_checkout = Path(f"{OUT}/fremake_canopy/test/null_model_full/src")
     mock_checkout.mkdir(parents = True)
 
@@ -140,15 +140,18 @@ def test_bm_checkout_force_checkout(caplog, monkeypatch):
                                            execute = False,
                                            force_checkout = True)
 
-    # Check it exists, check output, check content
+    renamed_src_dir = list(Path(f"{OUT}/fremake_canopy/test/null_model_full/").glob("src.*"))
+    # Check it exists, check previous src_dir was renamed check output, check content
     assert all([Path(f"{OUT}/fremake_canopy/test/null_model_full/src/checkout.sh").exists(),
+                renamed_src_dir[0].exists(),
+                Path(f"{renamed_src_dir[0]}/checkout.sh").exists(),
                 "Checkout script PREVIOUSLY created" in caplog.text,
-                "*** REMOVING CHECKOUT SCRIPT ***" in caplog.text,
+                "*** SRC DIR RENAMED:" in caplog.text,
+                "*** RE-CREATING CHECKOUT ***" in caplog.text,
                 "Checkout script created" in caplog.text])
 
     # Check one expected line is now populating the re-created checkout script
     expected_line = f"({EXPECTED_LINE}) &"
-
     with open(f"{OUT}/fremake_canopy/test/null_model_full/src/checkout.sh", 'r') as f2:
         content = f2.read()
 

--- a/fre/make/tests/test_create_checkout.py
+++ b/fre/make/tests/test_create_checkout.py
@@ -83,8 +83,10 @@ def test_checkout_execute(monkeypatch):
                 Path(f"{OUT}/fremake_canopy/test/null_model_full/src/coupler").is_dir(),
                 any(Path(f"{OUT}/fremake_canopy/test/null_model_full/src/coupler").iterdir())])
 
-def test_bm_checkout_again(caplog, monkeypatch):
+def test_bm_checkout_failure(caplog, monkeypatch):
     """
+    check for the raised OSError when the checkout script has been run,
+    but is executed again (without --force-checkout)
     """
     monkeypatch.setenv("TEST_BUILD_DIR", OUT)
 
@@ -101,10 +103,10 @@ def test_bm_checkout_again(caplog, monkeypatch):
                                                njobs = 2,
                                                execute = True,
                                                force_checkout = False)
+
     assert ([f"\nError executing checkout script: {OUT}/fremake_canopy/test/null_model_full/src/checkout.sh." in str(excinfo.value),
              f"\nTry removing test folder: {OUT}/fremake_canopy/test or  specifying --force-checkout" in str(excinfo.value)])
     
-
 def test_checkout_no_parallel_checkout(monkeypatch):
     """
     check if --no_parallel_checkout option works

--- a/fre/make/tests/test_create_checkout.py
+++ b/fre/make/tests/test_create_checkout.py
@@ -85,8 +85,8 @@ def test_checkout_execute(monkeypatch):
 
 def test_bm_checkout_failure(caplog, monkeypatch):
     """
-    check for the raised OSError when the checkout script has been run,
-    but is executed again (without --force-checkout)
+    check for the raised OSError when the checkout script is executed twice without
+    the --force-checkout option specified in the second execution
     """
     monkeypatch.setenv("TEST_BUILD_DIR", OUT)
 

--- a/fre/make/tests/test_run_fremake.py
+++ b/fre/make/tests/test_run_fremake.py
@@ -122,8 +122,8 @@ def test_run_fremake_force_checkout_serial(caplog):
                 "Checkout script created" in caplog.text,
                 Path(f"{SERIAL_TEST_PATH}/fremake_canopy/test/{EXPERIMENT}/src/checkout.sh").exists(),
                 renamed_src_dir[0].exists(),
-                Path(f"{renamed_src_dir[0]}/checkout.sh").exists(),
-                "Running fre make: (from force-checkout) removing previously generated compile script" in caplog.text])
+                Path(f"{renamed_src_dir[0]}/checkout.sh").exists()])
+#                "Running fre make: (from force-checkout) removing previously generated compile script" in caplog.text])
 
 # same tests with multijob compile and non-parallel-checkout options enabled
 def test_run_fremake_multijob():
@@ -194,8 +194,8 @@ def test_run_fremake_container_force_checkout():
     assert all(["Checkout script PREVIOUSLY created" in caplog.text,
                 "*** REMOVING CHECKOUT SCRIPT ***" in caplog.text,
                 "Checkout script created" in caplog.text,
-                Path(f"tmp/{CONTAINER_PLATFORM[0]}/checkout.sh").exists(),
-                "Running fre make: (from force-checkout) removing previously generated Dockerfile" in caplog.text])
+                Path(f"tmp/{CONTAINER_PLATFORM[0]}/checkout.sh").exists()])
+#                "Running fre make: (from force-checkout) removing previously generated Dockerfile" in caplog.text])
 
 # tests container 2 stage build script/makefile/dockerfile creation
 def test_run_fremake_container_2stage():

--- a/fre/make/tests/test_run_fremake.py
+++ b/fre/make/tests/test_run_fremake.py
@@ -122,7 +122,8 @@ def test_run_fremake_force_checkout_serial(caplog):
                 "Checkout script created" in caplog.text,
                 Path(f"{SERIAL_TEST_PATH}/fremake_canopy/test/{EXPERIMENT}/src/checkout.sh").exists(),
                 renamed_src_dir[0].exists(),
-                Path(f"{renamed_src_dir[0]}/checkout.sh").exists()])
+                Path(f"{renamed_src_dir[0]}/checkout.sh").exists(),
+                "Running fre make: (from force-checkout) removing previously generated compile script" in caplog.text])
 
 # same tests with multijob compile and non-parallel-checkout options enabled
 def test_run_fremake_multijob():
@@ -176,6 +177,25 @@ def test_run_fremake_makefile_creation_container():
 def test_run_fremake_run_script_creation_container():
     ''' checks (internal) container run script creation from previous test '''
     assert Path(f"tmp/{CONTAINER_PLATFORM[0]}/execrunscript.sh").exists()
+
+def test_run_fremake_container_force_checkout():
+   '''run run-fremake with options for containerized build and force-checkout'''
+    # double check the checkout script exists
+    assert Path(f"tmp/{CONTAINER_PLATFORM[0]}/checkout.sh").exists()
+
+    # run with force-checkout option
+    run_fremake_script.fremake_run(YAMLPATH, CONTAINER_PLATFORM, TARGET,
+        nparallel=False, makejobs=1, gitjobs=1, no_parallel_checkout=True,
+        no_format_transfer=False, execute=False, verbose=VERBOSE,
+        force_checkout=True)
+
+    renamed_src_dir = list(Path(f"{SERIAL_TEST_PATH}/fremake_canopy/test/{EXPERIMENT}/").glob("src.*"))
+    # Check it exists, check output, check content
+    assert all(["Checkout script PREVIOUSLY created" in caplog.text,
+                "*** REMOVING CHECKOUT SCRIPT ***" in caplog.text,
+                "Checkout script created" in caplog.text,
+                Path(f"tmp/{CONTAINER_PLATFORM[0]}/checkout.sh").exists(),
+                "Running fre make: (from force-checkout) removing previously generated Dockerfile" in caplog.text])
 
 # tests container 2 stage build script/makefile/dockerfile creation
 def test_run_fremake_container_2stage():

--- a/fre/make/tests/test_run_fremake.py
+++ b/fre/make/tests/test_run_fremake.py
@@ -178,7 +178,7 @@ def test_run_fremake_run_script_creation_container():
     ''' checks (internal) container run script creation from previous test '''
     assert Path(f"tmp/{CONTAINER_PLATFORM[0]}/execrunscript.sh").exists()
 
-def test_run_fremake_container_force_checkout():
+def test_run_fremake_container_force_checkout(caplog):
     '''run run-fremake with options for containerized build and force-checkout'''
     # double check the checkout script exists
     assert Path(f"tmp/{CONTAINER_PLATFORM[0]}/checkout.sh").exists()

--- a/fre/make/tests/test_run_fremake.py
+++ b/fre/make/tests/test_run_fremake.py
@@ -114,11 +114,15 @@ def test_run_fremake_force_checkout_serial(caplog):
         no_format_transfer=False, execute=False, verbose=VERBOSE,
         force_checkout=True)
 
+    renamed_src_dir = list(Path(f"{SERIAL_TEST_PATH}/fremake_canopy/test/{EXPERIMENT}/").glob("src.*"))
     # Check it exists, check output, check content
     assert all(["Checkout script PREVIOUSLY created" in caplog.text,
-                "*** REMOVING CHECKOUT SCRIPT ***" in caplog.text,
+                "*** SRC DIR RENAMED:" in caplog.text,
+                "*** RE-CREATING CHECKOUT ***" in caplog.text,
                 "Checkout script created" in caplog.text,
-                Path(f"{SERIAL_TEST_PATH}/fremake_canopy/test/{EXPERIMENT}/src/checkout.sh").exists()])
+                Path(f"{SERIAL_TEST_PATH}/fremake_canopy/test/{EXPERIMENT}/src/checkout.sh").exists(),
+                renamed_src_dir[0].exists(),
+                Path(f"{renamed_src_dir[0]}/checkout.sh").exists()])
 
 # same tests with multijob compile and non-parallel-checkout options enabled
 def test_run_fremake_multijob():

--- a/fre/make/tests/test_run_fremake.py
+++ b/fre/make/tests/test_run_fremake.py
@@ -179,7 +179,7 @@ def test_run_fremake_run_script_creation_container():
     assert Path(f"tmp/{CONTAINER_PLATFORM[0]}/execrunscript.sh").exists()
 
 def test_run_fremake_container_force_checkout():
-   '''run run-fremake with options for containerized build and force-checkout'''
+    '''run run-fremake with options for containerized build and force-checkout'''
     # double check the checkout script exists
     assert Path(f"tmp/{CONTAINER_PLATFORM[0]}/checkout.sh").exists()
 

--- a/fre/make/tests/test_run_fremake.py
+++ b/fre/make/tests/test_run_fremake.py
@@ -194,8 +194,8 @@ def test_run_fremake_container_force_checkout(caplog):
     assert all(["Checkout script PREVIOUSLY created" in caplog.text,
                 "*** REMOVING CHECKOUT SCRIPT ***" in caplog.text,
                 "Checkout script created" in caplog.text,
-                Path(f"tmp/{CONTAINER_PLATFORM[0]}/checkout.sh").exists()])
-#                "Running fre make: (from force-checkout) removing previously generated Dockerfile" in caplog.text])
+                Path(f"tmp/{CONTAINER_PLATFORM[0]}/checkout.sh").exists(),
+                "Running fre make: (from force-checkout) removing previously generated Dockerfile" in caplog.text])
 
 # tests container 2 stage build script/makefile/dockerfile creation
 def test_run_fremake_container_2stage():

--- a/fre/make/tests/test_run_fremake.py
+++ b/fre/make/tests/test_run_fremake.py
@@ -122,8 +122,8 @@ def test_run_fremake_force_checkout_serial(caplog):
                 "Checkout script created" in caplog.text,
                 Path(f"{SERIAL_TEST_PATH}/fremake_canopy/test/{EXPERIMENT}/src/checkout.sh").exists(),
                 renamed_src_dir[0].exists(),
-                Path(f"{renamed_src_dir[0]}/checkout.sh").exists()])
-#                "Running fre make: (from force-checkout) removing previously generated compile script" in caplog.text])
+                Path(f"{renamed_src_dir[0]}/checkout.sh").exists(),
+                "Running fre make: (from force-checkout) removing previously generated compile script" in caplog.text])
 
 # same tests with multijob compile and non-parallel-checkout options enabled
 def test_run_fremake_multijob():


### PR DESCRIPTION
## Describe your changes
Previously, the `--force-checkout` option removed the checkout script and src_dir that was already generated and re-created them. This did not mimic the current `--force-checkout` behavior in Bronx (which is also a bit more safe). If `--force-checkout` is used, the `src_dir` is renamed (in the same location) to `src.[timestamp]`.

This was only done for bare-metal builds. THe container build doesn't need this as the src code is INSIDE the container. 

- also changed `os` bits to `Path`

## Issue ticket number and link (if applicable)
Fixes #844  

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [x] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module

*Note: If you are a code maintainer updating the tag or releasing a new fre-cli version, please use the `release_procedure.md` template. To quickly use this template, open a new pull request, choose your branch, and add `?template=release_procedure.md` to the end of the url.*
