### PR TITLE
Schema update that forbids integers for start/stop years

### DIFF
--- a/docs/usage/postprocess.rst
+++ b/docs/usage/postprocess.rst
@@ -73,15 +73,21 @@ Required configuration
    settings:
      history_segment: P1Y
 
-3. Set the date range to postprocess as ISO8601 dates
+3. Set the date range to postprocess as ISO8601 dates (preferred) or four-digit year (YYYY).
 
 .. code-block:: console
 
  postprocess:
    settings:
-     pp_start: 1979-01-01T0000Z
+     pp_start: "1979-01-01T0000Z"
+     pp_stop: "2020-01-01T0000Z"
 
-     pp_stop: 2020-01-01T0000Z
+ or
+
+ postprocess:
+   settings:
+     pp_start: "1979"
+     pp_stop: "2020"
 
 Postprocess components
 ----------------------

--- a/fre/yamltools/tests/AM5_example/am5.yaml
+++ b/fre/yamltools/tests/AM5_example/am5.yaml
@@ -5,8 +5,8 @@ fre_properties:
   # amip
   - &EXP_AMIP_START     "1979"
   - &EXP_AMIP_END       "2020"
-  - &ANA_AMIP_START     1980
-  - &ANA_AMIP_END       2020
+  - &ANA_AMIP_START     "1980"
+  - &ANA_AMIP_END       "2020"
 
 #  - &PP_AMIP_CHUNK96    "P1Y"
   - &PP_AMIP_CHUNK384   "P1Y"


### PR DESCRIPTION
## Describe your changes
Submodule update to forbid integers for start/stop years, avoiding undesired octal to integer conversion.

https://github.com/NOAA-GFDL/gfdl_msd_schemas/pull/49

## Issue ticket number and link (if applicable)
Fixes #854

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module

*Note: If you are a code maintainer updating the tag or releasing a new fre-cli version, please use the `release_procedure.md` template. To quickly use this template, open a new pull request, choose your branch, and add `?template=release_procedure.md` to the end of the url.*
