### PR TITLE
Fix logic to determine non-desired variables in split-vars

### DIFF
--- a/fre/pp/split_netcdf_script.py
+++ b/fre/pp/split_netcdf_script.py
@@ -15,6 +15,7 @@ import sys
 from itertools import chain
 from os import path
 from pathlib import Path
+from typing import Dict, List, NoReturn, Optional, Union
 
 import xarray as xr
 import yaml
@@ -34,8 +35,15 @@ fre_logger = logging.getLogger(__name__)
 #hurt to double-check.
 METADATA_VAR_PATTERNS = ["_bnds", "_bounds", "_offset", "average_"]
 
-def split_netcdf(inputDir, outputDir, component, history_source, use_subdirs,
-                 yamlfile, split_all_vars=False):
+def split_netcdf(
+    inputDir: str,
+    outputDir: str,
+    component: str,
+    history_source: str,
+    use_subdirs: bool,
+    yamlfile: str,
+    split_all_vars: bool = False,
+) -> NoReturn:
     '''
     Given a directory of netcdf files, splits those netcdf files into separate
     files for each data variable and copies the data variable files of interest
@@ -160,7 +168,9 @@ def split_netcdf(inputDir, outputDir, component, history_source, use_subdirs,
     fre_logger.info(f"split-netcdf-wrapper call complete, having split {files_split} files")
     sys.exit(0) #check this
 
-def split_file_xarray(infile, outfiledir, var_list='all'):
+def split_file_xarray(
+    infile: str, outfiledir: str, var_list: Union[str, List[str]] = "all"
+) -> None:
     '''
     Given a netcdf infile containing one or more data variables,
     writes out a separate file for each data variable in the file, including the
@@ -205,7 +215,7 @@ def split_file_xarray(infile, outfiledir, var_list='all'):
     fre_logger.info(f"To exclude: var patterns matching '{METADATA_VAR_PATTERNS}'")
     fre_logger.info(f"To exclude: 1 or 2-d vars: '{metadata_vars_to_exclude_by_name}'")
     #both combined gets you a decent list of non-diagnostic variables
-    def is_metadata_var(var_to_check):
+    def is_metadata_var(var_to_check: str) -> bool:
         """
         Checks a variable name and determines whether it is a metadata variable
         and therefore should not be one of the split-by-variable output files, by
@@ -270,7 +280,7 @@ def split_file_xarray(infile, outfiledir, var_list='all'):
             data2.to_netcdf(var_out, encoding = var_encode)
             fre_logger.debug(f"Wrote '{var_out}'")
 
-def get_max_ndims(dataset):
+def get_max_ndims(dataset: xr.Dataset) -> int:
     '''
     Gets the maximum number of dimensions of a single var in an xarray
     Dataset object. Excludes coord vars, which should be single-dim anyway.
@@ -284,7 +294,7 @@ def get_max_ndims(dataset):
     ndims = [len(dataset[v].shape) for v in allvars]
     return max(ndims)
 
-def set_coord_encoding(dset, vcoords):
+def set_coord_encoding(dset: xr.Dataset, vcoords: List[str]) -> Dict[str, Dict[str, Union[None, str, type]]]:
     '''
     Gets the encoding settings needed for xarray to write out the coordinates
     as expected
@@ -318,7 +328,7 @@ def set_coord_encoding(dset, vcoords):
             encode_dict[vc]['units'] = dset[vc].encoding['units']
     return encode_dict
 
-def set_var_encoding(dset, varnames):
+def set_var_encoding(dset: xr.Dataset, varnames: List[str]) -> Dict[str, Dict[str, Union[None, str, type]]]:
     '''
     Gets the encoding settings needed for xarray to write out the variables
     as expected
@@ -345,7 +355,7 @@ def set_var_encoding(dset, varnames):
             encode_dict[v]['units'] = dset[v].encoding['units']
     return encode_dict
 
-def fre_outfile_name(infile, varname):
+def fre_outfile_name(infile: str, varname: str) -> str:
     '''
     Builds split  var filenames the way that fre expects them
     (and in a way that should work for any .nc file)

--- a/fre/pp/split_netcdf_script.py
+++ b/fre/pp/split_netcdf_script.py
@@ -32,7 +32,7 @@ fre_logger = logging.getLogger(__name__)
 #*_average: calculated averages for a variable.
 #These vars may also be covered by the var_shortvars query, but it doesn't
 #hurt to double-check.
-VAR_PATTERNS = ["_bnds", "_bounds", "_offset", "average_"]
+VAR_EXCLUDE_PATTERNS = ["_bnds", "_bounds", "_offset", "average_"]
 
 def split_netcdf(inputDir, outputDir, component, history_source, use_subdirs,
                  yamlfile, split_all_vars=False):
@@ -198,21 +198,30 @@ def split_file_xarray(infile, outfiledir, var_list='all'):
     #If they were, I could get away with the following:
     #var_zerovars = [v for v in datavars if not len(dataset[v].coords) > 0])
     #instead of this:
-    var_shortvars = [v for v in allvars if (len(dataset[v].shape) < varsize) and v not in dataset._coord_names]
+    shortvars_to_exclude = [v for v in allvars if (len(dataset[v].shape) < varsize) and v not in dataset._coord_names]
+    fre_logger.debug(f"Variables to be excluded (due to small number of dimensions): '{shortvars_to_exclude}'")
     #having a variable listed as both a metadata var and a coordinate var seems to
     #lead to the weird adding a _FillValue behavior
-    fre_logger.info(f"var patterns: {VAR_PATTERNS}")
-    fre_logger.info(f"1 or 2-d vars: {var_shortvars}")
+    fre_logger.info(f"To exclude: var patterns matching '{VAR_EXCLUDE_PATTERNS}'")
+    fre_logger.info(f"To exclude: 1 or 2-d vars: '{shortvars_to_exclude}'")
     #both combined gets you a decent list of non-diagnostic variables
-    var_exclude = list(set(VAR_PATTERNS + [str(el) for el in var_shortvars] ))
     def matchlist(xstr):
-        ''' checks a string for matches in a list of patterns
+        """
+        Checks a string for matches in patterns or exact names.
 
-            xstr: string to search for matches
-            var_exclude: list of patterns defined in VAR_EXCLUDE'''
-        allmatch = [re.search(el, xstr)for el in var_exclude]
-        #If there's at least one match in the var_exclude list (average_bnds is OK)
-        return len(list(set(allmatch))) > 1
+        xstr: string to search for matches
+        VAR_EXCLUDE_PATTERNS: list of patterns defined to exclude from output
+        shortvars_to_exclude: list of variables to exclude from output
+        """
+        # Check substring patterns from VAR_EXCLUDE_PATTERNS
+        for pattern in VAR_EXCLUDE_PATTERNS:
+            if re.search(pattern, xstr):
+                return True
+        # Check exact matches from shortvars_to_exclude
+        for name in shortvars_to_exclude:
+            if xstr == name:
+                return True
+        return False
     metavars = [el for el in allvars if matchlist(el)]
     datavars = [el for el in allvars if not matchlist(el)]
     fre_logger.debug(f"metavars: {metavars}")

--- a/fre/pp/split_netcdf_script.py
+++ b/fre/pp/split_netcdf_script.py
@@ -30,9 +30,9 @@ fre_logger = logging.getLogger(__name__)
 #*_offset: i and j offsets. Constants added to a coordinate var to get
 #   actual coordinate values, used to compress data
 #*_average: calculated averages for a variable.
-#These vars may also be covered by the var_shortvars query, but it doesn't
+#These vars may also be covered by the metadata_vars query, but it doesn't
 #hurt to double-check.
-VAR_EXCLUDE_PATTERNS = ["_bnds", "_bounds", "_offset", "average_"]
+METADATA_VAR_PATTERNS = ["_bnds", "_bounds", "_offset", "average_"]
 
 def split_netcdf(inputDir, outputDir, component, history_source, use_subdirs,
                  yamlfile, split_all_vars=False):
@@ -198,32 +198,39 @@ def split_file_xarray(infile, outfiledir, var_list='all'):
     #If they were, I could get away with the following:
     #var_zerovars = [v for v in datavars if not len(dataset[v].coords) > 0])
     #instead of this:
-    shortvars_to_exclude = [v for v in allvars if (len(dataset[v].shape) < varsize) and v not in dataset._coord_names]
-    fre_logger.debug(f"Variables to be excluded (due to small number of dimensions): '{shortvars_to_exclude}'")
+    metadata_vars_to_exclude_by_name = [v for v in allvars if (len(dataset[v].shape) < varsize) and v not in dataset._coord_names]
+    fre_logger.debug(f"Variables to be excluded (due to small number of dimensions): '{metadata_vars_to_exclude_by_name}'")
     #having a variable listed as both a metadata var and a coordinate var seems to
     #lead to the weird adding a _FillValue behavior
-    fre_logger.info(f"To exclude: var patterns matching '{VAR_EXCLUDE_PATTERNS}'")
-    fre_logger.info(f"To exclude: 1 or 2-d vars: '{shortvars_to_exclude}'")
+    fre_logger.info(f"To exclude: var patterns matching '{METADATA_VAR_PATTERNS}'")
+    fre_logger.info(f"To exclude: 1 or 2-d vars: '{metadata_vars_to_exclude_by_name}'")
     #both combined gets you a decent list of non-diagnostic variables
-    def matchlist(xstr):
+    def is_metadata_var(var_to_check):
         """
-        Checks a string for matches in patterns or exact names.
+        Checks a variable name and determines whether it is a metadata variable
+        and therefore should not be one of the split-by-variable output files, by
+        comparing the variable name to exact matches or pattern matches of known metadata variables.
+
+        This nested method is intended to be used only internally within this method (split_file_xarray),
+        and returns a list of true/false values for the list comprehensions around lines 225/226.
+        Values are TRUE if the criteria for a metadata-like variable are met (the two checked cases)
+        and FALSE if they are not (the fall-through case)
 
         xstr: string to search for matches
-        VAR_EXCLUDE_PATTERNS: list of patterns defined to exclude from output
-        shortvars_to_exclude: list of variables to exclude from output
+        METADATA_VAR_PATTERNS: list of patterns defined to exclude from output
+        metadata_vars_to_exclude_by_name: list of variables to exclude from output
         """
-        # Check substring patterns from VAR_EXCLUDE_PATTERNS
-        for pattern in VAR_EXCLUDE_PATTERNS:
-            if re.search(pattern, xstr):
+        # Check substring patterns from METADATA_VAR_PATTERNS
+        for pattern in METADATA_VAR_PATTERNS:
+            if re.search(pattern, var_to_check):
                 return True
-        # Check exact matches from shortvars_to_exclude
-        for name in shortvars_to_exclude:
-            if xstr == name:
+        # Check exact matches from metadata_vars_to_exclude_by_name
+        for name in metadata_vars_to_exclude_by_name:
+            if var_to_check == name:
                 return True
         return False
-    metavars = [el for el in allvars if matchlist(el)]
-    datavars = [el for el in allvars if not matchlist(el)]
+    metavars = [el for el in allvars if is_metadata_var(el)]
+    datavars = [el for el in allvars if not is_metadata_var(el)]
     fre_logger.debug(f"metavars: {metavars}")
     fre_logger.debug(f"datavars: {datavars}")
     fre_logger.debug(f"var filter list: {var_list}")

--- a/fre/pp/split_netcdf_script.py
+++ b/fre/pp/split_netcdf_script.py
@@ -25,15 +25,6 @@ from fre.app.helpers import get_variables
 
 fre_logger = logging.getLogger(__name__)
 
-#These are patterns used to match known kinds of metadata-like variables
-#in netcdf files
-#*_bnds, *_bounds: bounds variables. Defines the edges of a coordinate var
-#*_offset: i and j offsets. Constants added to a coordinate var to get
-#   actual coordinate values, used to compress data
-#*_average: calculated averages for a variable.
-#These vars may also be covered by the metadata_vars query, but it doesn't
-#hurt to double-check.
-METADATA_VAR_PATTERNS = ["_bnds", "_bounds", "_offset", "average_"]
 
 def split_netcdf(
     inputDir: str,
@@ -212,6 +203,17 @@ def split_file_xarray(
     fre_logger.debug(f"Variables to be excluded (due to small number of dimensions): '{metadata_vars_to_exclude_by_name}'")
     #having a variable listed as both a metadata var and a coordinate var seems to
     #lead to the weird adding a _FillValue behavior
+
+    # These are patterns used to match known kinds of metadata-like variables
+    # in netcdf files.
+    # *_bnds, *_bounds: bounds variables. Defines the edges of a coordinate var
+    # *_offset: i and j offsets. Constants added to a coordinate var to get
+    #       actual coordinate values, used to compress data
+    # *_average: calculated averages for a variable.
+    # These vars may also be covered by the metadata_vars query, but it doesn't
+    # hurt to double-check.
+    METADATA_VAR_PATTERNS = ["_bnds", "_bounds", "_offset", "average_"]
+
     fre_logger.info(f"To exclude: var patterns matching '{METADATA_VAR_PATTERNS}'")
     fre_logger.info(f"To exclude: 1 or 2-d vars: '{metadata_vars_to_exclude_by_name}'")
     #both combined gets you a decent list of non-diagnostic variables
@@ -226,10 +228,13 @@ def split_file_xarray(
         Values are TRUE if the criteria for a metadata-like variable are met (the two checked cases)
         and FALSE if they are not (the fall-through case)
 
-        xstr: string to search for matches
         METADATA_VAR_PATTERNS: list of patterns defined to exclude from output
         metadata_vars_to_exclude_by_name: list of variables to exclude from output
+
+        :param var_to_check: string to search for matches
+        :type var_to_check: string
         """
+
         # Check substring patterns from METADATA_VAR_PATTERNS
         for pattern in METADATA_VAR_PATTERNS:
             if re.search(pattern, var_to_check):

--- a/fre/pp/split_netcdf_script.py
+++ b/fre/pp/split_netcdf_script.py
@@ -228,8 +228,8 @@ def split_file_xarray(
         Values are TRUE if the criteria for a metadata-like variable are met (the two checked cases)
         and FALSE if they are not (the fall-through case)
 
-        METADATA_VAR_PATTERNS: list of patterns defined to exclude from output
-        metadata_vars_to_exclude_by_name: list of variables to exclude from output
+        METADATA_VAR_PATTERNS: list of regex patterns defined that match variables that should be excluded from the split-out files.
+        metadata_vars_to_exclude_by_name: list of variable names that should be excluded from the split-out files.
 
         :param var_to_check: string to search for matches
         :type var_to_check: string

--- a/fre/pp/tests/test_split_netcdf.py
+++ b/fre/pp/tests/test_split_netcdf.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import click
 import pytest
+import xarray as xr
 from click.testing import CliRunner
 
 from fre import fre
@@ -218,6 +219,72 @@ def test_split_file_metadata(workdir,newdir, origdir):
             print("comparison of " + nccmp_cmd[-1] + " and " + nccmp_cmd[-2] + " did not match")
             print(sp.stdout, sp.stderr)
     assert all_files_equal and same_count_files
+
+def test_variable_filtering_bug_fix():
+    ''' Test that variables with names containing short metadata var names are not excluded.
+    
+    This test verifies the fix for a bug where the matching logic was incorrectly applied
+    to both known patterns and the list of short variable names (e.g., "a", "b"), causing
+    variables like "drybc" to be excluded because they contain "b".
+    
+    The bug was that short vars were treated as patterns instead of exact matches.
+    '''
+    # Create a mock dataset with variables that would trigger the old bug
+    import numpy as np
+    import tempfile
+    
+    # Create dimensions
+    time = xr.DataArray(np.arange(10), dims=['time'])
+    lat = xr.DataArray(np.arange(5), dims=['lat'])
+    lon = xr.DataArray(np.arange(5), dims=['lon'])
+    
+    # Create variables: some data vars with names that contain short var letters
+    data_vars = {
+        'drybc': (['time', 'lat', 'lon'], np.random.rand(10, 5, 5)),  # Should be included
+        'wetbc': (['time', 'lat', 'lon'], np.random.rand(10, 5, 5)),  # Should be included
+        'temp': (['time', 'lat', 'lon'], np.random.rand(10, 5, 5)),   # Should be included
+        'a': (['time'], np.random.rand(10)),                          # Short var, should be excluded
+        'b': (['lat'], np.random.rand(5)),                            # Short var, should be excluded
+        'time_bnds': (['time', 'nv'], np.random.rand(10, 2)),         # Pattern match, should be excluded
+        'average_T1': (['time'], np.random.rand(10)),                 # Pattern match, should be excluded
+    }
+    
+    # Create coordinates
+    coords = {
+        'time': time,
+        'lat': lat,
+        'lon': lon,
+        'nv': [0, 1],
+    }
+    
+    ds = xr.Dataset(data_vars=data_vars, coords=coords)
+    
+    # Use a temporary directory for output
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Call split_file_xarray with "all" to get all data vars
+        split_file_xarray.__wrapped__ = split_file_xarray  # Access the original function
+        
+        # We need to test the internal logic. Since split_file_xarray writes files,
+        # let's test the filtering logic by inspecting the datavars.
+        # Actually, let's modify the function to return the datavars for testing.
+        
+        # For now, let's call it and check the output files
+        output_file = osp.join(tmpdir, 'test.nc')
+        # But split_file_xarray expects an input file, so we need to save ds first
+        input_file = osp.join(tmpdir, 'input.nc')
+        ds.to_netcdf(input_file)
+        
+        split_file_xarray(input_file, tmpdir, "all")
+        
+        # Check which files were created
+        output_files = [f for f in os.listdir(tmpdir) if f.endswith('.nc') and f != 'input.nc']
+        
+        # Expected data vars: drybc, wetbc, temp (3D+ vars)
+        # Excluded: a, b (1D), time_bnds (pattern), average_T1 (pattern)
+        expected_vars = {'drybc', 'wetbc', 'temp'}
+        actual_vars = {f.replace('input.', '').replace('.nc', '') for f in output_files}
+        
+        assert actual_vars == expected_vars, f"Expected {expected_vars}, got {actual_vars}"
 
 #clean up splitting files
 def test_split_file_cleanup():

--- a/fre/pp/tests/test_split_netcdf.py
+++ b/fre/pp/tests/test_split_netcdf.py
@@ -269,7 +269,6 @@ def test_variable_filtering_bug_fix():
         # Actually, let's modify the function to return the datavars for testing.
         
         # For now, let's call it and check the output files
-        output_file = osp.join(tmpdir, 'test.nc')
         # But split_file_xarray expects an input file, so we need to save ds first
         input_file = osp.join(tmpdir, 'input.nc')
         ds.to_netcdf(input_file)


### PR DESCRIPTION
The existing logic used both known patterns and a list of variables whose number of dimensions look like metadata. The problem was that the matching logic was applied to the patterns, which was fine, but also the "short var" list, e.g. "a" and "b". This caused any variable with "b" such as "drybc" to be excluded from the output.

## Describe your changes

## Issue ticket number and link (if applicable)
Fixes #862  (replace XXX with the issue number and GitHub will autolink the PR to the issue)
## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [x] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [x] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module

*Note: If you are a code maintainer updating the tag or releasing a new fre-cli version, please use the `release_procedure.md` template. To quickly use this template, open a new pull request, choose your branch, and add `?template=release_procedure.md` to the end of the url.*
