### PR TITLE
Remove yaml cleaning for fre_properties

### DIFF
--- a/fre/yamltools/helpers.py
+++ b/fre/yamltools/helpers.py
@@ -131,7 +131,7 @@ def clean_yaml(yml_dict):
     """
     # Clean the yaml
     # If keys exists, delete:
-    keys_clean=["fre_properties", "experiments"]
+    keys_clean=["experiments"]
     for kc in keys_clean:
         if kc in yml_dict.keys():
             del yml_dict[kc]

--- a/fre/yamltools/info_parsers/cmor_info_parser.py
+++ b/fre/yamltools/info_parsers/cmor_info_parser.py
@@ -353,7 +353,7 @@ class CMORYaml():
         """
         # Clean the yaml, the key exists, delete
         keys_clean=["name", "platform", "target", # these are needed to create the final parsed dictionary fed to cmor
-                    "fre_properties", "directories", "experiments",
+                    "directories", "experiments",
                     'build', 'postprocess']
 
         for kc in keys_clean:


### PR DESCRIPTION
So that the user-set values can be read by user plugins via the serialized yaml.

## Describe your changes

## Issue ticket number and link (if applicable)
Fixes #851 (replace XXX with the issue number and GitHub will autolink the PR to the issue)
## Checklist before requesting a review

- [x] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module

*Note: If you are a code maintainer updating the tag or releasing a new fre-cli version, please use the `release_procedure.md` template. To quickly use this template, open a new pull request, choose your branch, and add `?template=release_procedure.md` to the end of the url.*
