### PR TITLE
 Set `DO_ANALYSIS=False` in rose-suite if no analysis at all

### DIFF
--- a/fre/pp/configure_script_yaml.py
+++ b/fre/pp/configure_script_yaml.py
@@ -188,15 +188,18 @@ def set_rose_suite(yamlfile: dict, rose_suite: metomi.rose.config.ConfigNode) ->
                         value = 'False' )
 
     # Set DO_ANALYSIS switch
-    # analysis_on is optional key for each component in the analysis yaml and 
-    # defaults to True if not specified.
+    # If no analysis section is defined, set DO_ANALYSIS as False
+    # If anlaysis section is defined, analysis_on is optional key for each component
+    # in the analysis yaml and defaults to True if not specified.
     # In the rose_suite.conf:
     #  - if 'analysis_on: False' for all analysis components, set DO_ANALYSIS=False
     #  - if 'analysis_on: True' for any analysis components, set DO_ANALYSIS=True
-    do_analysis_switch = []
     if not analysis:
+        rose_suite.set( keys = ['template variables', 'DO_ANALYSIS'],
+                        value = 'False' )
         return
-        
+
+    do_analysis_switch = []    
     for an_key, an_value in analysis.items():
         an_workflow_info = an_value["workflow"]
         # if analysis_on key is actually set, evaluate and save its value in a list
@@ -206,7 +209,7 @@ def set_rose_suite(yamlfile: dict, rose_suite: metomi.rose.config.ConfigNode) ->
         else:
             do_analysis_switch.append("True")
 
-    # if ANY of the analysis components do not set analysis_on or set analysis_on: True,
+    # if ANY of the analysis components do not set analysis_on or set analysis_on as True,
     # set DO_ANALYSIS=True in the rose_suite.conf
     if any(do_analysis_switch):
         rose_suite.set( keys = ['template variables', 'DO_ANALYSIS'],


### PR DESCRIPTION
## Describe your changes
Previously, the function exits if there is no analysis section defined in the yaml at all but I forgot that the workflow will still look for the DO_ANALYSIS key set in the rose_suite.conf. 

- added line to set DO_ANALYSIS if no analysis section is defined 

## Issue ticket number and link (if applicable)
Fixes #847 

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module

*Note: If you are a code maintainer updating the tag or releasing a new fre-cli version, please use the `release_procedure.md` template. To quickly use this template, open a new pull request, choose your branch, and add `?template=release_procedure.md` to the end of the url.*
