### PR TITLE
Directories should be added to rose suite

### DIFF
--- a/fre/pp/configure_script_yaml.py
+++ b/fre/pp/configure_script_yaml.py
@@ -124,6 +124,10 @@ def set_rose_suite(yamlfile: dict, rose_suite: metomi.rose.config.ConfigNode) ->
     dirs=yamlfile.get("directories")
     analysis=yamlfile.get("analysis")
 
+    if dirs is not None:
+        for key,value in dirs.items():
+            rose_suite.set(keys=['template variables', key.upper()], value=quote_rose_values(value))
+
     # set rose-suite items
     pa_scripts = ""
     rd_scripts = ""
@@ -217,10 +221,6 @@ def set_rose_suite(yamlfile: dict, rose_suite: metomi.rose.config.ConfigNode) ->
     else:
         rose_suite.set( keys = ['template variables', 'DO_ANALYSIS'],
                         value = 'False' )
-
-    if dirs is not None:
-        for key,value in dirs.items():
-            rose_suite.set(keys=['template variables', key.upper()], value=quote_rose_values(value))
 
 ####################
 def yaml_info(yamlfile: str = None, experiment: str = None, platform: str = None, target: str = None) -> None:


### PR DESCRIPTION
## Describe your changes
....I'm so sorry....the directories should be added before the function potentially exits (due to a non-existent analysis section). This moves the directory information being added to the rose-suite first. 😬  (this would probably be caught earlier when we add the ability to specify a fre-cli fork to test with fre-workflows in the fre-workflow cloud runner test)

## Issue ticket number and link (if applicable)

## Checklist before requesting a review

- [ ] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module

*Note: If you are a code maintainer updating the tag or releasing a new fre-cli version, please use the `release_procedure.md` template. To quickly use this template, open a new pull request, choose your branch, and add `?template=release_procedure.md` to the end of the url.*
