### PR TITLE
add `pip` to requirements, add `pylint` workflow

### DIFF
--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -104,20 +104,6 @@ jobs:
           export PATH="$path_save"
           echo $PATH
 
-      - name: Run pylint On fre/ In fre-cli Env
-        run: |
-          echo "to run conda init, sourcing /some/path/to/conda/etc/profile.d/conda.sh"
-          source /opt/software/linux-rocky9-zen2/gcc-11.4.1/miniconda3-24.7.1-akg5caxhoqv3oasili3pgukbyryceq74/etc/profile.d/conda.sh
-
-          echo "to activate env, conda init"
-          conda init
-
-          echo "activating the fre-cli environment"
-          conda activate fre-cli
-
-          echo "running pylint on fre"
-          pylint --rcfile pylintrc fre/
-
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,55 @@
+name: pylint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+
+# cancel running jobs if theres a newer push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pylint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - name: Checkout Files
+        uses: actions/checkout@v4
+
+      - name: Setup Conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: fre-cli
+          environment-file: environment.yaml
+          auto-activate: false
+          miniforge-version: latest
+          conda-remove-defaults: true
+
+      - name: Configure Conda
+        run: |
+          echo "removing main and r channels from defaults"
+          conda config --remove channels defaults || true
+          conda config --remove channels main || true
+          conda config --remove channels r || true
+
+          echo "setting strict channel priority"
+          conda config --set channel_priority strict
+
+          echo "printing conda config just in case"
+          conda config --show
+
+      - name: Install fremor
+        run: |
+          pip install .
+
+      - name: Run pylint
+        run: |
+          pylint --rcfile pylintrc fre/

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -28,7 +28,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: fre-cli
-          environment-file: environment.yaml
+          environment-file: environment.yml
           auto-activate: false
           miniforge-version: latest
           conda-remove-defaults: true

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -46,7 +46,7 @@ jobs:
           echo "printing conda config just in case"
           conda config --show
 
-      - name: Install fremor
+      - name: Install fre
         run: |
           pip install .
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - noaa-gfdl
 dependencies:
   - python>=3.11
+  - pip
   - noaa-gfdl::analysis_scripts==0.0.1
   - noaa-gfdl::catalogbuilder==2025.01.01
 #  - noaa-gfdl::fre-nctools==2022.02.01

--- a/meta.yaml
+++ b/meta.yaml
@@ -7,11 +7,12 @@ source:
 
 build:
   script:
-    - {{ PYTHON }} -m pip install . -vv
+    - {{ PYTHON }} -m pip install . -vv --no-deps
     - cp fre/mkmf/bin/mkmf $PREFIX/bin
     - cp fre/mkmf/bin/list_paths $PREFIX/bin
     - cp fre/mkmf/bin/git-version-string $PREFIX/bin
   noarch: python
+  number: 0
 
 requirements:
   host:
@@ -43,13 +44,10 @@ requirements:
 
 test:
   requires:
-    - conda-forge::pylint
     - conda-forge::pytest
-    - conda-forge::pytest-cov
   source_files:
     - fre/
   files:
-    - pylintrc
     - fre/mkmf/templates/*
   imports:
     - fre
@@ -73,7 +71,6 @@ test:
     - fre pp --help
     - fre run --help
     - fre yamltools --help
-    - pylint --rcfile pylintrc fre/
     - pytest --durations=20 --log-level INFO --ignore=fre/make/tests/compilation fre/
 
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -13,19 +13,12 @@ build:
     - cp fre/mkmf/bin/git-version-string $PREFIX/bin
   noarch: python
 
-channels:
-    - conda-forge
-    - noaa-gfdl
-
 requirements:
-  build:
+  host:
     - python>=3.11
     - pip
     - setuptools
     - wheel
-  host:
-    - python>=3.11
-    - setuptools
   run:
     - python>=3.11
     - noaa-gfdl::analysis_scripts==0.0.1


### PR DESCRIPTION
## Describe your changes
`create_test_conda_env` failing with messages complaining about lack-of-`pip`, this should fix this in the relevant places. 

- new `.github/workflows/pylint.yml` for easier-to-find workflow feedback
- now redundant `pylint` calls in `create_test_conda_env`, `meta.yaml` removed
- some small changes and spurious data removed from `meta.yaml` in light of my `conda-forge` feedstock adventures (`--no-deps`, `build: number: 0`, remove redundant `build` section in favor of comprehensive `host` section

