### PR TITLE
explore clashing reqs in `environment.yml`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - noaa-gfdl::analysis_scripts==0.0.1
   - noaa-gfdl::catalogbuilder==2025.01.01
 #  - noaa-gfdl::fre-nctools==2022.02.01
-#  - conda-forge::cdo>=2
+  - conda-forge::cdo>=2
   - conda-forge::cftime
   - conda-forge::click>=8.2
   - conda-forge::cmor>=3.14.2
@@ -17,13 +17,13 @@ dependencies:
   - conda-forge::jinja2>=3
   - conda-forge::jsonschema
   - conda-forge::metomi-rose
-  - conda-forge::nccmp
+#  - conda-forge::nccmp
 #  - conda-forge::numpy==1.26.4
   - conda-forge::numpy>=2
   - conda-forge::pytest
   - conda-forge::pytest-cov
   - conda-forge::pylint
-#  - conda-forge::python-cdo
+  - conda-forge::python-cdo
   - conda-forge::pyyaml
   - conda-forge::xarray>=2024.*
   - conda-forge::netcdf4>=1.7.*

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - conda-forge::jinja2>=3
   - conda-forge::jsonschema
   - conda-forge::metomi-rose
-#  - conda-forge::nccmp
+  - conda-forge::nccmp
 #  - conda-forge::numpy==1.26.4
   - conda-forge::numpy>=2
   - conda-forge::pytest

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - conda-forge::cdo>=2
   - conda-forge::cftime
   - conda-forge::click>=8.2
-  - conda-forge::cmor>=3.14
+  - conda-forge::cmor>=3.14.2
   - conda-forge::cylc-flow>=8.2
   - conda-forge::cylc-rose
   - conda-forge::jinja2>=3

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - conda-forge::cdo>=2
   - conda-forge::cftime
   - conda-forge::click>=8.2
-  - conda-forge::cmor>=3.14.2
+  - conda-forge::cmor>=3.15.0
   - conda-forge::cylc-flow>=8.2
   - conda-forge::cylc-rose
   - conda-forge::jinja2>=3

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - noaa-gfdl::analysis_scripts==0.0.1
   - noaa-gfdl::catalogbuilder==2025.01.01
 #  - noaa-gfdl::fre-nctools==2022.02.01
-  - conda-forge::cdo>=2
+#  - conda-forge::cdo>=2
   - conda-forge::cftime
   - conda-forge::click>=8.2
   - conda-forge::cmor>=3.14.2
@@ -17,13 +17,13 @@ dependencies:
   - conda-forge::jinja2>=3
   - conda-forge::jsonschema
   - conda-forge::metomi-rose
-  - conda-forge::nccmp
+#  - conda-forge::nccmp
 #  - conda-forge::numpy==1.26.4
   - conda-forge::numpy>=2
   - conda-forge::pytest
   - conda-forge::pytest-cov
   - conda-forge::pylint
-  - conda-forge::python-cdo
+#  - conda-forge::python-cdo
   - conda-forge::pyyaml
   - conda-forge::xarray>=2024.*
   - conda-forge::netcdf4>=1.7.*


### PR DESCRIPTION
# TLDR summary
`nccmp` is still non-resolvable with `cmor>=3.14.2` in the same environment.
`cdo==2.5.0` is now resolvable with `cmor>=3.14.2` thanks to additional re-builds with [`libnetcdf`](https://github.com/conda-forge/cdo-feedstock/pull/174) and [`hdf5`](https://github.com/conda-forge/cdo-feedstock/pull/175)

## what's this for
double-checking incompatibility that was discovered between `cmor>=3.14.2` and `cdo`/`python-cdo`, and/or `nccmp`.

## results

### currently on `main`
the environment [resolves](https://github.com/NOAA-GFDL/fre-cli/actions?query=branch%3Amain)

### first commit
the environment resolution [gets stuck](https://github.com/NOAA-GFDL/fre-cli/actions/runs/26168292553/job/76978513892) when updating `cmor>=3.14.0` to `cmor>=3.14.2`, failing to resolve after about an hour.

### second commit
keeping `cmor>=3.14.2`, `nccmp`, `cdo`, and `python-cdo` are all commented out. in [this scenario](https://github.com/NOAA-GFDL/fre-cli/actions/runs/26171694434) (in progress as of this edit), we expect that the environment will resolve, but that tests will fail due to missing requirements. 
update: result is as expected, environment resolution, failing tests due to missing requirements.

### third commit
`cmor>=3.14.2`+`nccmp`, but no `cdo`/`python-cdo` --> no environment resolution expected, no tests run
update: [in-progress](https://github.com/NOAA-GFDL/fre-cli/actions/runs/26172596715/job/76994135578?pr=896), takes awhile --> check later
update: [result is as expected](https://github.com/NOAA-GFDL/fre-cli/actions/runs/26172596715/job/76994135518?pr=896)

### fourth commit
`cmor>=3.14.2`+`cdo`/`python-cdo`, but no `nccmp`
UPDATE: Environment resolution worked! tests run and fail, which is expected after environment resolution
