### PR TITLE
update for node24 migration

### DIFF
--- a/.github/workflows/build_conda.yml
+++ b/.github/workflows/build_conda.yml
@@ -1,4 +1,8 @@
 name: build_conda
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -1,5 +1,8 @@
 name: create_test_conda_env
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/publish_conda.yml
+++ b/.github/workflows/publish_conda.yml
@@ -1,4 +1,8 @@
 name: publish_conda
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,8 @@
 name: pylint
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches:

--- a/.github/workflows/spell_check.yml
+++ b/.github/workflows/spell_check.yml
@@ -1,4 +1,8 @@
 name: 'Check spelling'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/update_container_image.yaml
+++ b/.github/workflows/update_container_image.yaml
@@ -1,5 +1,8 @@
 name: Build and Push Container Image
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   workflow_dispatch:
   workflow_run:

--- a/.github/workflows/update_container_image.yaml
+++ b/.github/workflows/update_container_image.yaml
@@ -1,6 +1,8 @@
 name: Build and Push Container Image
 
 env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: "noaa-gfdl/fre-cli"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 on:
@@ -8,10 +10,6 @@ on:
   workflow_run:
     workflows: ["publish_conda"]
     types: [completed]
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: "noaa-gfdl/fre-cli"
 
 jobs:
   build-and-push:

--- a/.github/workflows/update_tag.yaml
+++ b/.github/workflows/update_tag.yaml
@@ -1,5 +1,8 @@
 name: Update Tag Version References
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     tags:


### PR DESCRIPTION
## Describe your changes
actions will now need to use node js 24 as node js 20 is being phased out (EOL)

this PR updates actions to use node js 24 github runners now. minimal friction expected, but better safe than sorry. 

## Issue ticket number and link (if applicable)
see the warnings attached to any workflow without the edits in this PR

