### PR TITLE
Make documentation updates

### DIFF
--- a/docs/tools/make.rst
+++ b/docs/tools/make.rst
@@ -15,22 +15,18 @@
   - ``-e, --execute`` Execute the checkout script immediately following its generation. The default behavior is to generate the script, but not execute.
   - ``--force-checkout`` Force a git checkout if the source directory already exists.
 
----
-
 ``makefile``
 ------------
 
 ``fre make makefile [options]``
 
 **Purpose:**
-  Writes a Makefile that will compile the model code[
+  Writes a Makefile that will compile the model code
 
 **Options:**
   - ``-y, --yamlfile [model yaml file]`` (required): Model configuration yaml FILENAME.
   - ``-p, --platform [platform]`` (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
   - ``-t, --target [target]`` (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
-
----
 
 ``compile``
 -----------
@@ -45,11 +41,9 @@
   - ``-p, --platform [platform]`` (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
   - ``-t, --target [target]`` (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
   - ``-mj, --makejobs [number]`` Number of make recipes to compile simultaneously (optional) (default 4).
-  - ``-n, --nparallel [number]`` Number of concurrent compile scripts to execute (optional) (default 1). This option is ignored when the argument --execute/-e is missing.
+  - ``-n, --nparallel [number]`` Number of concurrent compile scripts to execute (optional) (default 1). This option is ignored when the argument ``--execute/-e`` is missing.
   - ``-e, --execute`` Execute the compile script immediately following its generation. The default behavior is to generate the script, but not execute.
   - ``-v, --verbose`` Turns on debug level logging.
-
----
 
 ``dockerfile``
 --------------
@@ -66,8 +60,6 @@
   - ``-nft, --no-format-transfer`` Skip the container format conversion to a Singularity Image File (.sif).
   - ``-e, --execute`` Execute the createContainer script immediately following its generation. The default behavior is to generate the script, but not execute.
 
----
-
 ``all``
 -------
 
@@ -80,7 +72,7 @@
   - ``-y, --yamlfile [model yaml file]`` (required): Model configuration yaml FILENAME.
   - ``-p, --platform [platform]`` (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
   - ``-t, --target [target]`` (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
-  - ``-n, --nparallel [number]`` Number of concurrent compile scripts to execute (optional) (default 1). This option is ignored when the argument --execute/-e is missing.
+  - ``-n, --nparallel [number]`` Number of concurrent compile scripts to execute (optional) (default 1). This option is ignored when the argument ``--execute/-e`` is missing.
   - ``-mj, --makejobs [number]`` Number of make recipes to compile simultaneously (optional) (default 4).
   - ``-gj, --gitjobs [number]`` Number of git submodules to clone simultaneously (optional) (default 4).
   - ``-npc, --no-parallel-checkout`` Turns off parallel git clones. By default, fre make will clone each git repository in parallel.

--- a/docs/tools/make.rst
+++ b/docs/tools/make.rst
@@ -1,94 +1,90 @@
-==========================
-Make Subcommands Reference
-==========================
+``checkout``
+------------
 
-checkout
-========
-
-``fre make checkout-script [options]`` [cite: 2]
+``fre make checkout-script [options]``
 
 **Purpose:**
-  Writes a script that will clone (checkout) the model code from respective git repositories[cite: 3].
+  Writes a script that will clone (checkout) the model code from respective git repositories.
 
 **Options:**
-  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME[cite: 5].
-  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument[cite: 6].
-  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument[cite: 7].
-  -gj, --gitjobs [number]          Number of git submodules to clone simultaneously (optional) (default 4)[cite: 8].
-  -npc, --no-parallel-checkout     Turns off parallel git clones. By default, fre make will clone each git repository in parallel[cite: 9].
-  -e, --execute                    Execute the checkout script immediately following its generation[cite: 10]. The default behavior is to generate the script, but not execute[cite: 11].
-  --force-checkout                 Force a git checkout if the source directory already exists[cite: 12].
+  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME.
+  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
+  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
+  -gj, --gitjobs [number]          Number of git submodules to clone simultaneously (optional) (default 4).
+  -npc, --no-parallel-checkout     Turns off parallel git clones. By default, fre make will clone each git repository in parallel.
+  -e, --execute                    Execute the checkout script immediately following its generation. The default behavior is to generate the script, but not execute.
+  --force-checkout                 Force a git checkout if the source directory already exists.
 
 ---
 
-makefile
-========
+``makefile``
+------------
 
-``fre make makefile [options]`` [cite: 14]
+``fre make makefile [options]``
 
 **Purpose:**
-  Writes a Makefile that will compile the model code[cite: 15].
+  Writes a Makefile that will compile the model code[
 
 **Options:**
-  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME[cite: 17].
-  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument[cite: 18].
-  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument[cite: 19].
+  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME.
+  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
+  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
 
 ---
 
-compile
-=======
+``compile``
+-----------
 
-``fre make compile-script [options]`` [cite: 21]
+``fre make compile-script [options]``
 
 **Purpose:**
-  Writes a compile script that will configure the compile environment and execute make[cite: 22].
+  Writes a compile script that will configure the compile environment and execute make.
 
 **Options:**
-  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME[cite: 24].
-  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument[cite: 25].
-  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument[cite: 26].
-  -mj, --makejobs [number]         Number of make recipes to compile simultaneously (optional) (default 4)[cite: 27].
-  -n, --nparallel [number]         Number of concurrent compile scripts to execute (optional) (default 1)[cite: 28]. This option is ignored when the argument --execute/-e is missing[cite: 29].
-  -e, --execute                    Execute the compile script immediately following its generation[cite: 30]. The default behavior is to generate the script, but not execute[cite: 31].
-  -v, --verbose                    Turns on debug level logging[cite: 32].
+  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME.
+  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
+  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
+  -mj, --makejobs [number]         Number of make recipes to compile simultaneously (optional) (default 4).
+  -n, --nparallel [number]         Number of concurrent compile scripts to execute (optional) (default 1). This option is ignored when the argument --execute/-e is missing.
+  -e, --execute                    Execute the compile script immediately following its generation. The default behavior is to generate the script, but not execute.
+  -v, --verbose                    Turns on debug level logging.
 
 ---
 
-dockerfile
-==========
+``dockerfile``
+--------------
 
-``fre make dockerfile [options]`` [cite: 34]
+``fre make dockerfile [options]``
 
 **Purpose:**
-  Writes a Dockerfile and createContainer.sh script that will generate a container image (.sif format) containing the source code, Makefile, model executable, and dependent libraries[cite: 35].
+  Writes a Dockerfile and createContainer.sh script that will generate a container image (.sif format) containing the source code, Makefile, model executable, and dependent libraries.
 
 **Options:**
-  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME[cite: 37].
-  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument[cite: 38].
-  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument[cite: 39].
-  -nft, --no-format-transfer       Skip the container format conversion to a Singularity Image File (.sif)[cite: 40].
-  -e, --execute                    Execute the createContainer script immediately following its generation[cite: 41]. The default behavior is to generate the script, but not execute[cite: 42].
+  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME.
+  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
+  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
+  -nft, --no-format-transfer       Skip the container format conversion to a Singularity Image File (.sif).
+  -e, --execute                    Execute the createContainer script immediately following its generation. The default behavior is to generate the script, but not execute.
 
 ---
 
-all
-===
+``all``
+-------
 
-``fre make all [options]`` [cite: 44]
+``fre make all [options]``
 
 **Purpose:**
-  Executes the above fre make subcommands in the appropriate order to generate a model executable or container image (platform dependent)[cite: 45].
+  Executes the above fre make subcommands in the appropriate order to generate a model executable or container image (platform dependent).
 
 **Options:**
-  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME[cite: 47].
-  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument[cite: 48].
-  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument[cite: 49].
-  -n, --nparallel [number]         Number of concurrent compile scripts to execute (optional) (default 1)[cite: 50]. This option is ignored when the argument --execute/-e is missing[cite: 51].
-  -mj, --makejobs [number]         Number of make recipes to compile simultaneously (optional) (default 4)[cite: 52].
-  -gj, --gitjobs [number]          Number of git submodules to clone simultaneously (optional) (default 4)[cite: 53].
-  -npc, --no-parallel-checkout     Turns off parallel git clones. By default, fre make will clone each git repository in parallel[cite: 54].
-  -nft, --no-format-transfer       Skip the container format conversion to a Singularity Image File (.sif)[cite: 55].
-  -e, --execute                    Execute the checkout and compile/createContainer scripts immediately following their generation[cite: 56]. The default behavior is to generate the scripts, but not execute[cite: 57].
-  --force-checkout                 Force a git checkout if the source directory already exists[cite: 58].
-  -v, --verbose                    Turns on debug level logging[cite: 59].
+  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME.
+  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
+  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
+  -n, --nparallel [number]         Number of concurrent compile scripts to execute (optional) (default 1). This option is ignored when the argument --execute/-e is missing.
+  -mj, --makejobs [number]         Number of make recipes to compile simultaneously (optional) (default 4).
+  -gj, --gitjobs [number]          Number of git submodules to clone simultaneously (optional) (default 4).
+  -npc, --no-parallel-checkout     Turns off parallel git clones. By default, fre make will clone each git repository in parallel.
+  -nft, --no-format-transfer       Skip the container format conversion to a Singularity Image File (.sif).
+  -e, --execute                    Execute the checkout and compile/createContainer scripts immediately following their generation. The default behavior is to generate the scripts, but not execute.
+  --force-checkout                 Force a git checkout if the source directory already exists.
+  -v, --verbose                    Turns on debug level logging.

--- a/docs/tools/make.rst
+++ b/docs/tools/make.rst
@@ -7,13 +7,13 @@
   Writes a script that will clone (checkout) the model code from respective git repositories.
 
 **Options:**
-  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME.
-  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
-  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
-  -gj, --gitjobs [number]          Number of git submodules to clone simultaneously (optional) (default 4).
-  -npc, --no-parallel-checkout     Turns off parallel git clones. By default, fre make will clone each git repository in parallel.
-  -e, --execute                    Execute the checkout script immediately following its generation. The default behavior is to generate the script, but not execute.
-  --force-checkout                 Force a git checkout if the source directory already exists.
+  - ``-y, --yamlfile [model yaml file]`` (required): Model configuration yaml FILENAME.
+  - ``-p, --platform [platform]`` (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
+  - ``-t, --target [target]`` (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
+  - ``-gj, --gitjobs [number]`` Number of git submodules to clone simultaneously (optional) (default 4).
+  - ``-npc, --no-parallel-checkout`` Turns off parallel git clones. By default, fre make will clone each git repository in parallel.
+  - ``-e, --execute`` Execute the checkout script immediately following its generation. The default behavior is to generate the script, but not execute.
+  - ``--force-checkout`` Force a git checkout if the source directory already exists.
 
 ---
 
@@ -26,9 +26,9 @@
   Writes a Makefile that will compile the model code[
 
 **Options:**
-  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME.
-  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
-  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
+  - ``-y, --yamlfile [model yaml file]`` (required): Model configuration yaml FILENAME.
+  - ``-p, --platform [platform]`` (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
+  - ``-t, --target [target]`` (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
 
 ---
 
@@ -41,13 +41,13 @@
   Writes a compile script that will configure the compile environment and execute make.
 
 **Options:**
-  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME.
-  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
-  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
-  -mj, --makejobs [number]         Number of make recipes to compile simultaneously (optional) (default 4).
-  -n, --nparallel [number]         Number of concurrent compile scripts to execute (optional) (default 1). This option is ignored when the argument --execute/-e is missing.
-  -e, --execute                    Execute the compile script immediately following its generation. The default behavior is to generate the script, but not execute.
-  -v, --verbose                    Turns on debug level logging.
+  - ``-y, --yamlfile [model yaml file]`` (required): Model configuration yaml FILENAME.
+  - ``-p, --platform [platform]`` (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
+  - ``-t, --target [target]`` (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
+  - ``-mj, --makejobs [number]`` Number of make recipes to compile simultaneously (optional) (default 4).
+  - ``-n, --nparallel [number]`` Number of concurrent compile scripts to execute (optional) (default 1). This option is ignored when the argument --execute/-e is missing.
+  - ``-e, --execute`` Execute the compile script immediately following its generation. The default behavior is to generate the script, but not execute.
+  - ``-v, --verbose`` Turns on debug level logging.
 
 ---
 

--- a/docs/tools/make.rst
+++ b/docs/tools/make.rst
@@ -60,11 +60,11 @@
   Writes a Dockerfile and createContainer.sh script that will generate a container image (.sif format) containing the source code, Makefile, model executable, and dependent libraries.
 
 **Options:**
-  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME.
-  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
-  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
-  -nft, --no-format-transfer       Skip the container format conversion to a Singularity Image File (.sif).
-  -e, --execute                    Execute the createContainer script immediately following its generation. The default behavior is to generate the script, but not execute.
+  - ``-y, --yamlfile [model yaml file]`` (required): Model configuration yaml FILENAME.
+  - ``-p, --platform [platform]`` (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
+  - ``-t, --target [target]`` (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
+  - ``-nft, --no-format-transfer`` Skip the container format conversion to a Singularity Image File (.sif).
+  - ``-e, --execute`` Execute the createContainer script immediately following its generation. The default behavior is to generate the script, but not execute.
 
 ---
 
@@ -77,14 +77,14 @@
   Executes the above fre make subcommands in the appropriate order to generate a model executable or container image (platform dependent).
 
 **Options:**
-  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME.
-  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
-  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
-  -n, --nparallel [number]         Number of concurrent compile scripts to execute (optional) (default 1). This option is ignored when the argument --execute/-e is missing.
-  -mj, --makejobs [number]         Number of make recipes to compile simultaneously (optional) (default 4).
-  -gj, --gitjobs [number]          Number of git submodules to clone simultaneously (optional) (default 4).
-  -npc, --no-parallel-checkout     Turns off parallel git clones. By default, fre make will clone each git repository in parallel.
-  -nft, --no-format-transfer       Skip the container format conversion to a Singularity Image File (.sif).
-  -e, --execute                    Execute the checkout and compile/createContainer scripts immediately following their generation. The default behavior is to generate the scripts, but not execute.
-  --force-checkout                 Force a git checkout if the source directory already exists.
-  -v, --verbose                    Turns on debug level logging.
+  - ``-y, --yamlfile [model yaml file]`` (required): Model configuration yaml FILENAME.
+  - ``-p, --platform [platform]`` (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument.
+  - ``-t, --target [target]`` (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument.
+  - ``-n, --nparallel [number]`` Number of concurrent compile scripts to execute (optional) (default 1). This option is ignored when the argument --execute/-e is missing.
+  - ``-mj, --makejobs [number]`` Number of make recipes to compile simultaneously (optional) (default 4).
+  - ``-gj, --gitjobs [number]`` Number of git submodules to clone simultaneously (optional) (default 4).
+  - ``-npc, --no-parallel-checkout`` Turns off parallel git clones. By default, fre make will clone each git repository in parallel.
+  - ``-nft, --no-format-transfer`` Skip the container format conversion to a Singularity Image File (.sif).
+  - ``-e, --execute`` Execute the checkout and compile/createContainer scripts immediately following their generation. The default behavior is to generate the scripts, but not execute.
+  - ``--force-checkout`` Force a git checkout if the source directory already exists.
+  - ``-v, --verbose`` Turns on debug level logging.

--- a/docs/tools/make.rst
+++ b/docs/tools/make.rst
@@ -1,59 +1,94 @@
-``checkout``
-------------
+==========================
+Make Subcommands Reference
+==========================
 
-``fre make checkout-script [options]``
-   - Purpose: Creates the checkout script and can check out source code (with execute option)
-   - Options:
-        - ``-y, --yamlfile [experiment yaml] (required)``
-        - ``-p, --platform [platform] (required)``
-        - ``-t, --target [target] (required)``
-        - ``-j, --njobs [number of jobs to run simultaneously]``
-        - ``-npc, --no-parallel-checkout (for container build)``
-        - ``-e, --execute``
+checkout
+========
 
-``makefile`` 
--------------
+``fre make checkout-script [options]`` [cite: 2]
 
-``fre make makefile [options]``
-   - Purpose: Creates the makefile
-   - Options:
-        - ``-y, --yamlfile [experiment yaml] (required)``
-        - ``-p, --platform [platform] (required)``
-        - ``-t, --target [target] (required)``
+**Purpose:**
+  Writes a script that will clone (checkout) the model code from respective git repositories[cite: 3].
 
-``compile``
------------
+**Options:**
+  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME[cite: 5].
+  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument[cite: 6].
+  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument[cite: 7].
+  -gj, --gitjobs [number]          Number of git submodules to clone simultaneously (optional) (default 4)[cite: 8].
+  -npc, --no-parallel-checkout     Turns off parallel git clones. By default, fre make will clone each git repository in parallel[cite: 9].
+  -e, --execute                    Execute the checkout script immediately following its generation[cite: 10]. The default behavior is to generate the script, but not execute[cite: 11].
+  --force-checkout                 Force a git checkout if the source directory already exists[cite: 12].
 
-``fre make compile-script [options]``
-   - Purpose: Creates the compile script and compiles the model (with execute option)
-   - Options:
-        - ``-y, --yamlfile [experiment yaml] (required)``
-        - ``-p, --platform [platform] (required)``
-        - ``-t, --target [target] (required)``
-        - ``-j, --njobs [number of jobs to run simultaneously]``
-        - ``-n, --parallel [number of concurrent module compiles]``
-        - ``-e, --execute``
+---
 
-``dockerfile``
---------------
+makefile
+========
 
-``fre make dockerfile [options]``
-   - Purpose: Creates the dockerfile and creates the container (with execute option)
-   - With the creation of the dockerfile, the Makefile, checkout script, and any other necessary script is copied into the container from a temporary location
-   - Options:
-        - ``-y, --yamlfile [experiment yaml] (required)``
-        - ``-p, --platform [platform] (required)``
-        - ``-t, --target [target] (required)``
+``fre make makefile [options]`` [cite: 14]
 
-``all``
--------
+**Purpose:**
+  Writes a Makefile that will compile the model code[cite: 15].
 
-``fre make all [options]``
-   - Purpose: Create the checkout script, Makefile, compile script, and dockerfile (platform dependent) for the compilation of the model
-   - Options:
-        - ``-y, --yamlfile [experiment yaml] (required)``
-        - ``-p, --platform [platform] (required)``
-        - ``-t, --target [target] (required)``
-        - ``-npc, --no-parallel-checkout (for container build)``
-        - ``-j, --njobs [number of jobs to run simultaneously]``
-        - ``-n, --parallel [number of concurrent module compiles]``
+**Options:**
+  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME[cite: 17].
+  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument[cite: 18].
+  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument[cite: 19].
+
+---
+
+compile
+=======
+
+``fre make compile-script [options]`` [cite: 21]
+
+**Purpose:**
+  Writes a compile script that will configure the compile environment and execute make[cite: 22].
+
+**Options:**
+  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME[cite: 24].
+  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument[cite: 25].
+  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument[cite: 26].
+  -mj, --makejobs [number]         Number of make recipes to compile simultaneously (optional) (default 4)[cite: 27].
+  -n, --nparallel [number]         Number of concurrent compile scripts to execute (optional) (default 1)[cite: 28]. This option is ignored when the argument --execute/-e is missing[cite: 29].
+  -e, --execute                    Execute the compile script immediately following its generation[cite: 30]. The default behavior is to generate the script, but not execute[cite: 31].
+  -v, --verbose                    Turns on debug level logging[cite: 32].
+
+---
+
+dockerfile
+==========
+
+``fre make dockerfile [options]`` [cite: 34]
+
+**Purpose:**
+  Writes a Dockerfile and createContainer.sh script that will generate a container image (.sif format) containing the source code, Makefile, model executable, and dependent libraries[cite: 35].
+
+**Options:**
+  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME[cite: 37].
+  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument[cite: 38].
+  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument[cite: 39].
+  -nft, --no-format-transfer       Skip the container format conversion to a Singularity Image File (.sif)[cite: 40].
+  -e, --execute                    Execute the createContainer script immediately following its generation[cite: 41]. The default behavior is to generate the script, but not execute[cite: 42].
+
+---
+
+all
+===
+
+``fre make all [options]`` [cite: 44]
+
+**Purpose:**
+  Executes the above fre make subcommands in the appropriate order to generate a model executable or container image (platform dependent)[cite: 45].
+
+**Options:**
+  -y, --yamlfile [model yaml file]  (required): Model configuration yaml FILENAME[cite: 47].
+  -p, --platform [platform]        (required) (repeatable): FRE platform string. Define multiple platforms by repeating this argument[cite: 48].
+  -t, --target [target]            (required) (repeatable): mkmf target string. Define multiple targets by repeating this argument[cite: 49].
+  -n, --nparallel [number]         Number of concurrent compile scripts to execute (optional) (default 1)[cite: 50]. This option is ignored when the argument --execute/-e is missing[cite: 51].
+  -mj, --makejobs [number]         Number of make recipes to compile simultaneously (optional) (default 4)[cite: 52].
+  -gj, --gitjobs [number]          Number of git submodules to clone simultaneously (optional) (default 4)[cite: 53].
+  -npc, --no-parallel-checkout     Turns off parallel git clones. By default, fre make will clone each git repository in parallel[cite: 54].
+  -nft, --no-format-transfer       Skip the container format conversion to a Singularity Image File (.sif)[cite: 55].
+  -e, --execute                    Execute the checkout and compile/createContainer scripts immediately following their generation[cite: 56]. The default behavior is to generate the scripts, but not execute[cite: 57].
+  --force-checkout                 Force a git checkout if the source directory already exists[cite: 58].
+  -v, --verbose                    Turns on debug level logging[cite: 59].

--- a/docs/usage/guides/fre_make_guide.rst
+++ b/docs/usage/guides/fre_make_guide.rst
@@ -1,117 +1,121 @@
+=====
 Guide
-----------
-1. Bare-metal Build:
+=====
 
-.. code-block::
+Bare-metal Build:
+-----------------
 
-  # Create checkout script
-  fre make checkout-script -y [model yaml file] -p [platform] -t [target]
+.. code-block:: bash
 
-  # Or create and RUN checkout script
-  fre make checkout-script -y [model yaml file] -p [platform] -t [target] --execute
+   # Create checkout script
+   fre make checkout-script -y [model yaml file] -p [platform] -t [target]
 
-  # Create Makefile
-  fre make makefile -y [model yaml file] -p [platform] -t [target]
+   # Or create and RUN checkout script
+   fre make checkout-script -y [model yaml file] -p [platform] -t [target] --execute
 
-  # Create the compile script
-  fre make compile-script -y [model yaml file] -p [platform] -t [target]
+   # Create Makefile
+   fre make makefile -y [model yaml file] -p [platform] -t [target]
 
-  # Or create and RUN the compile script
-  fre make compile-script -y [model yaml file] -p [platform] -t [target] --execute
+   # Create the compile script
+   fre make compile-script -y [model yaml file] -p [platform] -t [target]
+
+   # Or create and RUN the compile script
+   fre make compile-script -y [model yaml file] -p [platform] -t [target] --execute
 
 Users can also run all fre make commands in one subtool:
 
-.. code-block::
+.. code-block:: bash
 
-  # Run all of fremake: creates checkout script, makefile, compile script, and model executable
-  fre make all -y [model yaml file] -p [platform] -t [target] [other options...] --execute
+   # Run all of fremake: creates checkout script, makefile, compile script, and model executable
+   fre make all -y [model yaml file] -p [platform] -t [target] [other options...] --execute
 
-2. Container Build:
+Container Build:
+----------------
 
-For the container build, parallel checkouts are not supported. In addition the platform must be a container platform.
-
+For the container build, parallel checkouts are not supported (use the -npc flag). 
+In addition, the platform must be a container platform. 
 Gaea users will not be able to create containers unless they have requested and been given podman access.
 
-.. code-block::
+.. code-block:: bash
 
-  # Create checkout script
-  fre make checkout-script -y [model yaml file] -p [CONTAINER PLATFORM] -t [target]
+   # Create checkout script (turning off parallel checkout)
+   fre make checkout-script -y [model yaml file] -p [CONTAINER PLATFORM] -t [target] -npc
 
-  # Create Makefile
-  fre make makefile -y [model yaml file] -p [CONTAINER PLATFORM] -t [target]
+   # Create Makefile
+   fre make makefile -y [model yaml file] -p [CONTAINER PLATFORM] -t [target]
 
-  # Create a Dockerfile
-  fre make dockerfile -y [model yaml file] -p [CONTAINER PLATFORM] -t [target]
+   # Create a Dockerfile and createContainer.sh script
+   fre make dockerfile -y [model yaml file] -p [CONTAINER PLATFORM] -t [target]
 
-  # Or create and RUN the Dockerfile
-  fre make dockerfile -y [model yaml file] -p [CONTAINER PLATFORM] -t [target] --execute
+   # Or create and RUN the container build script
+   fre make dockerfile -y [model yaml file] -p [CONTAINER PLATFORM] -t [target] --execute
 
-To run all of fre make subtools:
+To run all of fre make subtools for a container build:
 
-.. code-block::
+.. code-block:: bash
 
-  # Run all of fremake: create and checkout script, makefile, dockerfile, container
-  # creation script, and model container
-  fre make all  -y [model yaml file] -p [CONTAINER PLATFORM] -t [target] --execute
+   # Run all of fremake: create and run checkout script, makefile, dockerfile, container
+   # creation script, and build the model container
+   fre make all -y [model yaml file] -p [CONTAINER PLATFORM] -t [target] -npc --execute
 
 Quickstart
 ----------
+
 The quickstart instructions can be used with the null model example located in the fre-cli repository: https://github.com/NOAA-GFDL/fre-cli/tree/main/fre/make/tests/null_example
 
-1. Bare-metal Build:
+Bare-metal Build:
+^^^^^^^^^^^^^^^^^
 
-.. code-block::
+.. code-block:: bash
 
-  # Create and run checkout script: checkout script will check out source code as
-                                    defined in the compile.yaml
-  fre make checkout-script -y null_model.yaml -p ncrc5.intel23 -t prod --execute
+   # Create and run checkout script: checkout script will check out source code as defined in the compile.yaml
+   fre make checkout-script -y null_model.yaml -p ncrc5.intel23 -t prod --execute
 
-  # Create Makefile
-  fre make makefile -y null_model.yaml -p ncrc5.intel23 -t prod
+   # Create Makefile
+   fre make makefile -y null_model.yaml -p ncrc5.intel23 -t prod
 
-  # Create and run the compile script to generate a model executable
-  fre make compile-script -y null_model.yaml -p ncrc5.intel23 -t prod --execute
+   # Create and run the compile script to generate a model executable
+   fre make compile-script -y null_model.yaml -p ncrc5.intel23 -t prod --execute
 
-2. Bare-metal Build Multi-target:
+Bare-metal Build Multi-target:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block::
+.. code-block:: bash
 
-  # Create and run checkout script: checkout script will check out source code as
-                                    defined in the compile.yaml
-  fre make checkout-script -y null_model.yaml -p ncrc5.intel23 -t prod -t debug --execute
+   # Create and run checkout script: checkout script will check out source code as defined in the compile.yaml for multiple targets
+   fre make checkout-script -y null_model.yaml -p ncrc5.intel23 -t prod -t debug --execute
 
-  # Create Makefile
-  fre make makefile -y null_model.yaml -p ncrc5.intel23 -t prod -t debug
+   # Create Makefile
+   fre make makefile -y null_model.yaml -p ncrc5.intel23 -t prod -t debug
 
-  # Create and run a compile script for each target specified; generates model executables
-  fre make compile-script -y null_model.yaml -p ncrc5.intel23 -t prod -t debug --execute
+   # Create and run a compile script for each target specified; generates model executables
+   fre make compile-script -y null_model.yaml -p ncrc5.intel23 -t prod -t debug --execute
 
-3. Container Build:
+Container Build:
+^^^^^^^^^^^^^^^^
 
-In order for the container to build successfully, the parallel checkout feature is disabled.
+In order for the container to build successfully, the parallel checkout feature is disabled using the -npc option.
 
-.. code-block::
+.. code-block:: bash
 
-  # Create checkout script
-  fre make checkout-script -y null_model.yaml -p hpcme.2023 -t prod
+   # Create checkout script
+   fre make checkout-script -y null_model.yaml -p hpcme.2023 -t prod -npc
 
-  # Create Makefile
-  fre make makefile -y null_model.yaml -p hpcme.2023 -t prod
+   # Create Makefile
+   fre make makefile -y null_model.yaml -p hpcme.2023 -t prod
 
-  # Create the Dockerfile and container build script: the container build script (createContainer.sh)
-                                                      uses the Dockerfile to build a model container
-  fre make dockerfile -y null_model.yaml -p hpcme.2023 -t prod --execute
+   # Create the Dockerfile and container build script: the container build script (createContainer.sh) uses the Dockerfile to build a model container
+   fre make dockerfile -y null_model.yaml -p hpcme.2023 -t prod --execute
 
-4. Run all of fremake:
+Run all of fremake:
+^^^^^^^^^^^^^^^^^^^
 
-`all` kicks off the compilation automatically
+The all command kicks off the entire process automatically when using --execute.
 
-.. code-block::
+.. code-block:: bash
 
-  # Bare-metal: create and run checkout script, create makefile, create and RUN compile script to
-                generate a model executable
-  fre make all -y null_model.yaml -p ncrc5.intel23 -t prod --execute
+   # Bare-metal: create and run checkout script, create makefile, create and RUN compile script to generate a model executable
+   fre make all -y null_model.yaml -p ncrc5.intel23 -t prod --execute
 
-  # Container: create checkout script, makefile, create dockerfile, and create and RUN the container
-               build script to generate a model container
-  fre make all -y null_model.yaml -p hpcme.2023 -t prod --execute
+   # Container: create checkout script, makefile, create dockerfile, and create and RUN the container build script to generate a model container
+   fre make all -y null_model.yaml -p hpcme.2023 -t prod -npc --execute

--- a/docs/usage/guides/fre_make_guide.rst
+++ b/docs/usage/guides/fre_make_guide.rst
@@ -1,9 +1,7 @@
-=====
 Guide
-=====
+------
 
 Bare-metal Build:
------------------
 
 .. code-block:: bash
 
@@ -30,7 +28,6 @@ Users can also run all fre make commands in one subtool:
    fre make all -y [model yaml file] -p [platform] -t [target] [other options...] --execute
 
 Container Build:
-----------------
 
 For the container build, parallel checkouts are not supported (use the -npc flag). 
 In addition, the platform must be a container platform. 
@@ -64,7 +61,6 @@ Quickstart
 The quickstart instructions can be used with the null model example located in the fre-cli repository: https://github.com/NOAA-GFDL/fre-cli/tree/main/fre/make/tests/null_example
 
 Bare-metal Build:
-^^^^^^^^^^^^^^^^^
 
 .. code-block:: bash
 
@@ -78,7 +74,6 @@ Bare-metal Build:
    fre make compile-script -y null_model.yaml -p ncrc5.intel23 -t prod --execute
 
 Bare-metal Build Multi-target:
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: bash
 
@@ -92,7 +87,6 @@ Bare-metal Build Multi-target:
    fre make compile-script -y null_model.yaml -p ncrc5.intel23 -t prod -t debug --execute
 
 Container Build:
-^^^^^^^^^^^^^^^^
 
 In order for the container to build successfully, the parallel checkout feature is disabled using the -npc option.
 
@@ -108,7 +102,6 @@ In order for the container to build successfully, the parallel checkout feature 
    fre make dockerfile -y null_model.yaml -p hpcme.2023 -t prod --execute
 
 Run all of fremake:
-^^^^^^^^^^^^^^^^^^^
 
 The all command kicks off the entire process automatically when using --execute.
 

--- a/fre/make/fremake.py
+++ b/fre/make/fremake.py
@@ -150,7 +150,8 @@ def all(yamlfile, platform, target, nparallel, makejobs, gitjobs, no_parallel_ch
               "--no-parallel-checkout",
               is_flag = True,
               help = _NO_PARALLEL_CHECKOUT_OPT_HELP)
-@click.option("--execute",
+@click.option("-e",
+              "--execute",
               is_flag = True,
               default = False,
               help = """Execute the checkout script immediately following its generation.
@@ -211,7 +212,8 @@ def makefile(yamlfile, platform, target):
               type = int,
               metavar = '', default = 1,
               help = _PARALLEL_OPT_HELP)
-@click.option("--execute",
+@click.option("-e",
+              "--execute",
               is_flag = True,
               default = False,
               help = """Execute the compile script immediately following its generation.
@@ -246,7 +248,8 @@ def compile_script(yamlfile, platform, target, makejobs, nparallel, execute, ver
               is_flag = True,
               default = False,
               help = "Skip the container format conversion to a Singularity Image File.")
-@click.option("--execute",
+@click.option("-e",
+              "--execute",
               is_flag = True,
               default = False,
               help = """Execute the createContainer script immediately following its generation.


### PR DESCRIPTION
## Describe your changes
This changes fremake documentation in the docs/ directory (rst files) and in the fremake.py cli interface defining file.

Background info:
I noticed that the ``--execute/-e arguments`` in ``fremake.py`` varied by subtool:
``fre make all`` supported -e and --execute
``fre make checkout-script`` supported only --execute
`` fre make compile-script`` supported only --execute
``fre make dockerfile`` supported only --execute
And I also noticed that the documentation in the docs/ directory stated that:
``fre make all`` didn't mention execute at all
``fre make checkout-script`` supported -e and --execute
`` fre make compile-script`` supported -e and --execute
``fre make dockerfile`` didn't mention execute at all

As a result:

I made changes to ``fremake.py`` to have all subtools suport ``--ecxecute`` and ``-e``
I then used AI (Gemini 3.5 Flash in the web browser) to update ``docs/tools/make.rst`` and ``docs/usage/guides/fre_make_guide.rst`` based on ``fremake.py``
I made changes to what AI produced.

## Issue ticket number and link (if applicable)
N/A

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [x] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [x] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module

*Note: If you are a code maintainer updating the tag or releasing a new fre-cli version, please use the `release_procedure.md` template. To quickly use this template, open a new pull request, choose your branch, and add `?template=release_procedure.md` to the end of the url.*
