### PR TITLE
Fix remap-pp-component's legacy date forming

### DIFF
--- a/fre/app/remap_pp_components/remap_pp_components.py
+++ b/fre/app/remap_pp_components/remap_pp_components.py
@@ -131,9 +131,9 @@ def chunk_to_legacy(iso_dura: str) -> str:
 
     if iso_dura[0]=='P':
         if iso_dura[-1:]=='M':
-            brx_freq=iso_dura[1]+'mo'
+            brx_freq=iso_dura[1:-1]+'mo'
         elif iso_dura[-1:]=='Y':
-            brx_freq=iso_dura[1]+'yr'
+            brx_freq=iso_dura[1:-1]+'yr'
         else:
             brx_freq = 'error'
     else:

--- a/fre/app/remap_pp_components/tests/test_remap_pp_components.py
+++ b/fre/app/remap_pp_components/tests/test_remap_pp_components.py
@@ -88,6 +88,18 @@ def test_yaml_ex_exists():
     """
     assert Path(YAML_EX).exists()
 
+## UNIT TESTS ##
+def test_chunk_to_legacy():
+    """
+    Test conversion of ISO8601 durations to Bronx-style chunk
+    frequencies, including multi-digit values
+    """
+    assert rmp.chunk_to_legacy("P1Y") == "1yr"
+    assert rmp.chunk_to_legacy("P10Y") == "10yr"
+    assert rmp.chunk_to_legacy("P5M") == "5mo"
+    assert rmp.chunk_to_legacy("P12M") == "12mo"
+    assert rmp.chunk_to_legacy("P1D") == "error"
+
 ## CREATE TEST FILES ##
 def test_create_ncfile_with_ncgen_cdl():
     """


### PR DESCRIPTION
## Describe your changes
Fix remap-pp-component's legacy date calculation for double digit years

## Issue ticket number and link (if applicable)
fixes #917

## Checklist before requesting a review

- [x] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [x] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module

*Note: If you are a code maintainer updating the tag or releasing a new fre-cli version, please use the `release_procedure.md` template. To quickly use this template, open a new pull request, choose your branch, and add `?template=release_procedure.md` to the end of the url.*
