### PR TITLE
Fix tag-update workflow failing on every tag push

### DIFF
--- a/.github/workflows/update_tag.yaml
+++ b/.github/workflows/update_tag.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Fetch tags
         run: |
-          git fetch --tags origin
+          git fetch --tags --force origin
  
       - name: Get the new tag
         id: get_tag


### PR DESCRIPTION
actions/checkout creates a local refs/tags/<name> ref for the triggering tag before the "Fetch tags" step runs git fetch --tags, which then rejects with "would clobber existing tag" since the fetch is not forced. Force the fetch so the workflow can proceed.

## Describe your changes

## Issue ticket number and link (if applicable)
Fixes #XXX (replace XXX with the issue number and GitHub will autolink the PR to the issue)
## Checklist before requesting a review

- [ ] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module

*Note: If you are a code maintainer updating the tag or releasing a new fre-cli version, please use the `release_procedure.md` template. To quickly use this template, open a new pull request, choose your branch, and add `?template=release_procedure.md` to the end of the url.*
