### PR TITLE
Update publish-conda to use the new tag for the package version

### DIFF
--- a/.github/workflows/publish_conda.yml
+++ b/.github/workflows/publish_conda.yml
@@ -3,15 +3,30 @@ name: publish_conda
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Run this action on pushes to main or after the update-tag action has run.
+# We detect the latter case by a closed pull request on a main push
+#   AND the if-condition that checks that the source branch is the
+#   one triggered by the update-tag reference changes.
+# The "Set version for tagged release" is needed to inform conda-build
+#   of the tag. Because there are intermediate commits (the updated version refs)
+#   the commit no longer is tagged. So we can retrieve the package version
+#   from __init__.py.
 on:
   push:
     branches:
       - main
-    tags:
-      - '*'
+  pull_request:
+    types: [closed]
+    branches:
+      - main
 
 jobs:
   condapublish:
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true &&
+       startsWith(github.event.pull_request.head.ref, 'update-version-post-release'))
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/noaa-gfdl/fre-cli:miniconda24_gcc14_v2
@@ -20,6 +35,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+
+      - name: Set version for tagged release
+        if: github.event_name == 'pull_request'
+        run: |
+          VERSION=$(python3 -c "
+          import re
+          content = open('fre/__init__.py').read()
+          m = re.search(r'GIT_DESCRIBE_TAG\",\s*\"([^\"]+)\"', content)
+          print(m.group(1))
+          ")
+          echo "GIT_DESCRIBE_TAG=$VERSION" >> $GITHUB_ENV
 
       - name: Configure Conda
         run: |

--- a/.github/workflows/publish_conda.yml
+++ b/.github/workflows/publish_conda.yml
@@ -36,6 +36,12 @@ jobs:
         with:
           submodules: 'recursive'
 
+      # For tagged releases, determine the tag from the __init__.py.
+      # Then make it available for the conda-build steps by setting the env var
+      # $GIT_DESCRIBE_TAG to the determined tag.
+      # $GITHUB_ENV is a special file path provided by the Actions runner.
+      # When you write KEY=VALUE lines into it, those variables become available
+      # as environment variables for all subsequent steps in the same job.
       - name: Set version for tagged release
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/publish_conda.yml
+++ b/.github/workflows/publish_conda.yml
@@ -24,9 +24,9 @@ jobs:
   condapublish:
     if: |
       github.event_name == 'push' ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.merged == true &&
-       startsWith(github.event.pull_request.head.ref, 'update-version-post-release'))
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.merged == true &&
+         startsWith(github.event.pull_request.head.ref, 'update-version-post-release'))
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/noaa-gfdl/fre-cli:miniconda24_gcc14_v2


### PR DESCRIPTION
## Describe your changes
Run the publish-conda action on pushes to main or after the update-tag action has run.

We detect the latter case by a closed pull request on a main push AND the if-condition that checks that the source branch is the one triggered by the update-tag reference changes.

The "Set version for tagged release" is needed to inform conda-build of the tag. Because there are intermediate commits (the updated version refs) the commit no longer is tagged. So we can retrieve the package version from __init__.py

## Issue ticket number and link (if applicable)
Fixes #921

## Checklist before requesting a review

- [ ] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module

*Note: If you are a code maintainer updating the tag or releasing a new fre-cli version, please use the `release_procedure.md` template. To quickly use this template, open a new pull request, choose your branch, and add `?template=release_procedure.md` to the end of the url.*
