### PR TITLE
feat(yamltools): validate inputs before combining

### DIFF
--- a/fre/yamltools/README.md
+++ b/fre/yamltools/README.md
@@ -13,6 +13,28 @@
         - `-e,  --experiment [experiment name]`
         - `--use [compile|pp] (required)`
 
+## Individual YAML validation
+
+Before combining files, `consolidate_yamls` validates each input using the
+convention for its role. This happens at the YAML parser-event level, so an
+individual file can be checked before aliases that refer to anchors in another
+file are resolved.
+
+| YAML kind | Required top-level keys | Optional top-level keys |
+| --- | --- | --- |
+| model | `experiments` | `build`, `fre_cli_version`, `fre_properties` |
+| compile | `compile` | `fre_properties` |
+| platforms | `platforms` | `fre_properties` |
+| post-processing | `postprocess` | `fre_properties` |
+| analysis | `analysis` | `fre_properties` |
+| CMOR | `cmor` | `fre_properties`, `grids` |
+| grids | `grids` | `fre_properties` |
+| settings | `directories`, `postprocess` | `fre_properties` |
+
+Validation rejects missing or unexpected top-level keys, duplicate top-level
+keys, and values with the wrong collection shape. Errors name both the YAML
+kind and file that must be corrected.
+
 ### **Tests**
 
 To run `fre yamltools` test scripts, return to root directory of the fre-cli repo and call those tests with

--- a/fre/yamltools/combine_yamls_script.py
+++ b/fre/yamltools/combine_yamls_script.py
@@ -36,6 +36,7 @@ from fre.yamltools.info_parsers import compile_info_parser as cip
 from fre.yamltools.info_parsers import pp_info_parser as ppip
 from fre.yamltools.info_parsers import analysis_info_parser as aip
 from fre.yamltools.helpers import output_yaml, check_fre_version
+from fre.yamltools.validation import validate_yaml_inputs
 
 from . import *
 
@@ -75,6 +76,9 @@ def consolidate_yamls(yamlfile:str, experiment:str, platform:str,
     ..note:: The output file name should include a .yaml extension to indicate
              it is a YAML configuration file
     """
+    # Validate each input independently before cross-file anchors are resolved.
+    validate_yaml_inputs(yamlfile, experiment, use)
+
     # Check fre_cli_version compatibility before any YAML combining
     fre_logger.info('checking fre_cli_version compatibility...')
     check_fre_version(yamlfile)

--- a/fre/yamltools/tests/esm4_cmip6_ex/esm4_cmip6.yaml
+++ b/fre/yamltools/tests/esm4_cmip6_ex/esm4_cmip6.yaml
@@ -51,10 +51,10 @@ experiments:
       - ''
 
   - name: "ESM4_TOAR_2014climo_2050ozone_v2"
+    settings: "pp_yamls/settings.yaml"
     grid_yaml:
       - "grid_yamls/TEST_grids.yaml"
     pp:
-      - "pp_yamls/settings.yaml"
       - "pp_yamls/pp.yaml"
     cmor:
       - "cmor_yamls/cmor.yaml"

--- a/fre/yamltools/tests/test_validation.py
+++ b/fre/yamltools/tests/test_validation.py
@@ -1,0 +1,74 @@
+"""Tests for validating FRE YAML files before they are combined."""
+
+from pathlib import Path
+
+import pytest
+
+from fre.yamltools.validation import YamlKind, validate_yaml_file, validate_yaml_inputs
+
+
+TEST_DIR = Path("fre/yamltools/tests/AM5_example")
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "kind"),
+    [
+        ("am5.yaml", YamlKind.MODEL),
+        ("compile_yamls/compile.yaml", YamlKind.COMPILE),
+        ("compile_yamls/platforms.yaml", YamlKind.PLATFORMS),
+        ("pp_yamls/pp.c96_amip.yaml", YamlKind.PP),
+        ("analysis_yamls/clouds.yaml", YamlKind.ANALYSIS),
+        ("cmor_yamls/cmor.am5.yaml", YamlKind.CMOR),
+        ("grid_yamls/TEST_grids.yaml", YamlKind.GRIDS),
+        ("settings.yaml", YamlKind.SETTINGS),
+    ],
+)
+def test_each_yaml_kind_accepts_current_example(relative_path, kind):
+    """Every current example follows its kind's top-level convention."""
+    validate_yaml_file(TEST_DIR / relative_path, kind)
+
+
+def test_validation_does_not_resolve_cross_file_aliases():
+    """An input can be validated while its aliases are still unresolved."""
+    validate_yaml_file(TEST_DIR / "compile_yamls/compile.yaml", YamlKind.COMPILE)
+
+
+def test_invalid_kind_reports_unexpected_top_level_key(tmp_path):
+    """A file with another kind's key is rejected before combination."""
+    compile_yaml = tmp_path / "compile.yaml"
+    compile_yaml.write_text("postprocess: {}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing top-level key.*compile"):
+        validate_yaml_file(compile_yaml, YamlKind.COMPILE)
+
+
+def test_invalid_top_level_value_type_is_reported(tmp_path):
+    """Top-level collections must have the shape required by their kind."""
+    platforms_yaml = tmp_path / "platforms.yaml"
+    platforms_yaml.write_text("platforms: {}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must contain a sequence, not a mapping"):
+        validate_yaml_file(platforms_yaml, YamlKind.PLATFORMS)
+
+
+def test_duplicate_top_level_key_is_reported(tmp_path):
+    """Duplicate top-level keys cannot silently overwrite one another."""
+    pp_yaml = tmp_path / "pp.yaml"
+    pp_yaml.write_text("postprocess: {}\npostprocess: {}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate top-level key 'postprocess'"):
+        validate_yaml_file(pp_yaml, YamlKind.PP)
+
+
+def test_validate_compile_inputs_follows_model_references():
+    """Compile validation follows both paths in the model's build section."""
+    validate_yaml_inputs(TEST_DIR / "am5.yaml", "am5", "compile")
+
+
+def test_validate_pp_inputs_follows_selected_experiment_references():
+    """PP validation follows settings, PP, and analysis references."""
+    validate_yaml_inputs(
+        TEST_DIR / "am5.yaml",
+        "c96L65_am5f7b12r1_amip",
+        "pp",
+    )

--- a/fre/yamltools/validation.py
+++ b/fre/yamltools/validation.py
@@ -1,0 +1,242 @@
+"""Validation for the individual YAML files that make up an FRE workflow."""
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+from yaml.events import (
+    AliasEvent,
+    DocumentEndEvent,
+    DocumentStartEvent,
+    MappingEndEvent,
+    MappingStartEvent,
+    ScalarEvent,
+    SequenceEndEvent,
+    SequenceStartEvent,
+    StreamEndEvent,
+    StreamStartEvent,
+)
+
+from fre.yamltools.helpers import yaml_load
+
+
+class YamlKind(StrEnum):
+    """The supported roles of files in an FRE YAML configuration."""
+
+    MODEL = "model"
+    COMPILE = "compile"
+    PLATFORMS = "platforms"
+    PP = "pp"
+    ANALYSIS = "analysis"
+    CMOR = "cmor"
+    GRIDS = "grids"
+    SETTINGS = "settings"
+
+
+class NodeKind(StrEnum):
+    """The YAML collection and scalar shapes used by the conventions."""
+
+    MAPPING = "mapping"
+    SEQUENCE = "sequence"
+    SCALAR = "scalar"
+    ALIAS = "alias"
+
+
+@dataclass(frozen=True)
+class YamlConvention:
+    """Required and optional top-level keys for one YAML kind."""
+
+    required: dict[str, NodeKind]
+    optional: dict[str, NodeKind]
+
+
+COMMON_OPTIONAL = {"fre_properties": NodeKind.SEQUENCE}
+
+CONVENTIONS = {
+    YamlKind.MODEL: YamlConvention(
+        required={"experiments": NodeKind.SEQUENCE},
+        optional={
+            **COMMON_OPTIONAL,
+            "fre_cli_version": NodeKind.SCALAR,
+            "build": NodeKind.MAPPING,
+        },
+    ),
+    YamlKind.COMPILE: YamlConvention(
+        required={"compile": NodeKind.MAPPING},
+        optional=COMMON_OPTIONAL,
+    ),
+    YamlKind.PLATFORMS: YamlConvention(
+        required={"platforms": NodeKind.SEQUENCE},
+        optional=COMMON_OPTIONAL,
+    ),
+    YamlKind.PP: YamlConvention(
+        required={"postprocess": NodeKind.MAPPING},
+        optional=COMMON_OPTIONAL,
+    ),
+    YamlKind.ANALYSIS: YamlConvention(
+        required={"analysis": NodeKind.MAPPING},
+        optional=COMMON_OPTIONAL,
+    ),
+    YamlKind.CMOR: YamlConvention(
+        required={"cmor": NodeKind.MAPPING},
+        optional={**COMMON_OPTIONAL, "grids": NodeKind.SEQUENCE},
+    ),
+    YamlKind.GRIDS: YamlConvention(
+        required={"grids": NodeKind.SEQUENCE},
+        optional=COMMON_OPTIONAL,
+    ),
+    YamlKind.SETTINGS: YamlConvention(
+        required={
+            "directories": NodeKind.MAPPING,
+            "postprocess": NodeKind.MAPPING,
+        },
+        optional=COMMON_OPTIONAL,
+    ),
+}
+
+
+def _consume_node(first_event, events: Iterable) -> NodeKind:
+    """Consume one parser-event node and return its collection shape."""
+
+    if isinstance(first_event, ScalarEvent):
+        return NodeKind.SCALAR
+    if isinstance(first_event, AliasEvent):
+        return NodeKind.ALIAS
+    if isinstance(first_event, SequenceStartEvent):
+        for event in events:
+            if isinstance(event, SequenceEndEvent):
+                return NodeKind.SEQUENCE
+            _consume_node(event, events)
+        raise ValueError("unterminated sequence")
+    if isinstance(first_event, MappingStartEvent):
+        for event in events:
+            if isinstance(event, MappingEndEvent):
+                return NodeKind.MAPPING
+            _consume_node(event, events)
+            try:
+                value_event = next(events)
+            except StopIteration as exc:
+                raise ValueError("mapping key has no value") from exc
+            _consume_node(value_event, events)
+        raise ValueError("unterminated mapping")
+    raise ValueError(f"unsupported YAML event {type(first_event).__name__}")
+
+
+def _top_level_shape(path: Path) -> dict[str, NodeKind]:
+    """Parse top-level keys without resolving aliases from other files."""
+
+    try:
+        events = iter(yaml.parse(path.read_text(encoding="utf-8")))
+        event = next(events)
+        if not isinstance(event, StreamStartEvent):
+            raise ValueError("missing YAML stream start")
+
+        event = next(events)
+        if not isinstance(event, DocumentStartEvent):
+            raise ValueError("missing YAML document start")
+
+        event = next(events)
+        if not isinstance(event, MappingStartEvent):
+            raise ValueError("the document root must be a mapping")
+
+        shape = {}
+        for event in events:
+            if isinstance(event, MappingEndEvent):
+                break
+            if not isinstance(event, ScalarEvent):
+                raise ValueError("top-level keys must be strings")
+            if event.value in shape:
+                raise ValueError(f"duplicate top-level key '{event.value}'")
+
+            try:
+                value_event = next(events)
+            except StopIteration as exc:
+                raise ValueError(f"top-level key '{event.value}' has no value") from exc
+            shape[event.value] = _consume_node(value_event, events)
+        else:
+            raise ValueError("unterminated root mapping")
+
+        if not isinstance(next(events), DocumentEndEvent):
+            raise ValueError("missing YAML document end")
+        if not isinstance(next(events), StreamEndEvent):
+            raise ValueError("FRE YAML files must contain exactly one document")
+        return shape
+    except (OSError, StopIteration, yaml.YAMLError, ValueError) as exc:
+        raise ValueError(f"Invalid YAML structure in '{path}': {exc}") from exc
+
+
+def validate_yaml_file(path: str | Path, kind: YamlKind) -> None:
+    """Validate one FRE YAML file against its pre-combination convention."""
+
+    path = Path(path)
+    if not path.is_file():
+        raise ValueError(f"{kind.value} YAML file does not exist: '{path}'")
+
+    shape = _top_level_shape(path)
+    convention = CONVENTIONS[kind]
+    expected = convention.required | convention.optional
+
+    missing = convention.required.keys() - shape.keys()
+    if missing:
+        keys = ", ".join(sorted(missing))
+        raise ValueError(f"Invalid {kind.value} YAML '{path}': missing top-level key(s): {keys}")
+
+    unexpected = shape.keys() - expected.keys()
+    if unexpected:
+        keys = ", ".join(sorted(unexpected))
+        raise ValueError(f"Invalid {kind.value} YAML '{path}': unexpected top-level key(s): {keys}")
+
+    for key, actual_kind in shape.items():
+        expected_kind = expected[key]
+        if actual_kind != expected_kind:
+            raise ValueError(
+                f"Invalid {kind.value} YAML '{path}': top-level key '{key}' "
+                f"must contain a {expected_kind.value}, not a {actual_kind.value}"
+            )
+
+
+def _referenced_path(model_path: Path, reference: str) -> Path:
+    return model_path.parent / reference
+
+
+def _selected_experiment(model: dict, experiment: str) -> dict:
+    experiments = model.get("experiments", [])
+    selected = next((item for item in experiments if item.get("name") == experiment), None)
+    if selected is None:
+        raise ValueError(f"{experiment} is not in the list of experiments")
+    return selected
+
+
+def validate_yaml_inputs(model_path: str | Path, experiment: str, use: str) -> None:
+    """Validate every individual YAML that will participate in consolidation."""
+
+    model_path = Path(model_path)
+    validate_yaml_file(model_path, YamlKind.MODEL)
+    model = yaml_load(model_path)
+
+    if use == "compile":
+        build = model.get("build")
+        if not isinstance(build, dict):
+            raise ValueError(f"Invalid model YAML '{model_path}': compile use requires a build mapping")
+        references = (
+            (build.get("compileYaml"), YamlKind.COMPILE),
+            (build.get("platformYaml"), YamlKind.PLATFORMS),
+        )
+    elif use == "pp":
+        selected = _selected_experiment(model, experiment)
+        references = [
+            (selected.get("settings"), YamlKind.SETTINGS),
+            *((path, YamlKind.PP) for path in selected.get("pp", [])),
+            *((path, YamlKind.ANALYSIS) for path in selected.get("analysis", [])),
+        ]
+    else:
+        return
+
+    for reference, kind in references:
+        if not isinstance(reference, str) or not reference:
+            if kind in (YamlKind.SETTINGS, YamlKind.ANALYSIS):
+                continue
+            raise ValueError(f"Invalid model YAML '{model_path}': missing {kind.value} YAML path")
+        validate_yaml_file(_referenced_path(model_path, reference), kind)


### PR DESCRIPTION
## Describe your changes

Validate each model, compile, platforms, post-processing, analysis, CMOR, grids, and settings YAML against its individual top-level convention before consolidation. The validator works on PyYAML parser events, so files that reference anchors defined in other inputs can be checked without resolving those aliases first.

This also moves the ESM4 settings file to the dedicated settings reference, adds focused validation tests, and documents the conventions and error behavior.

AI-assisted contribution: implementation and tests were prepared with Codex and reviewed against the repository contribution guidance.

## Issue ticket number and link

Fixes #611

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [x] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected its output
- [x] I ran pylint and attempted to implement its feedback
- [x] No print statements; all user-facing info uses logging module

## Validation

- `python -m pytest -q fre/yamltools/tests`: 31 passed, 1 skipped
- `python -m pytest -q fre/yamltools/tests/test_validation.py fre/yamltools/tests/test_combine_yamls_script.py`: 26 passed, 1 skipped
- `pylint fre/yamltools/validation.py fre/yamltools/tests/test_validation.py`: 10.00/10
- `git diff --check`