### PR TITLE
Replace os.getcwd() calls in fre/app

### DIFF
--- a/fre/app/helpers.py
+++ b/fre/app/helpers.py
@@ -75,7 +75,7 @@ def change_directory(new_path: str):
     :type new_path: str
     """
     ## Get current working directory
-    original_path = os.getcwd()
+    original_path = Path.cwd()
 
     ## Change into path passed
     os.chdir(new_path)

--- a/fre/app/regrid_xy/tests/test_regrid_xy.py
+++ b/fre/app/regrid_xy/tests/test_regrid_xy.py
@@ -2,7 +2,6 @@
 tests for fre.app.regrid_xy submodule
 '''
 
-import os
 from pathlib import Path
 import shutil
 from shutil import which
@@ -20,13 +19,13 @@ HAVE_FREGRID = WHICH_FREGRID is not None and WHICH_FREGRID.split('/')[-1] == 'fr
 nxy = 20
 date = "20250729"
 
-curr_dir = os.getcwd()
-yamlfile = Path(curr_dir)/"test_yaml.yaml"
-grid_spec_tar = Path(curr_dir)/"grid_spec.tar"
-input_dir = Path(curr_dir)/"test_inputs"
-output_dir = Path(curr_dir)/"test_outputs"
-remap_dir= Path(curr_dir)/"test_remap"
-work_dir = Path(curr_dir)/"test_work"
+curr_dir = Path.cwd()
+yamlfile = curr_dir / "test_yaml.yaml"
+grid_spec_tar = curr_dir / "grid_spec.tar"
+input_dir = curr_dir / "test_inputs"
+output_dir = curr_dir / "test_outputs"
+remap_dir = curr_dir / "test_remap"
+work_dir = curr_dir / "test_work"
 
 input_files             = [{"history_file":"pemberley"}, {"history_file":"longbourn"}]
 input_files_donotregrid = [{"history_file":"nope"}]

--- a/fre/app/remap_pp_components/tests/test_remap_pp_components.py
+++ b/fre/app/remap_pp_components/tests/test_remap_pp_components.py
@@ -7,9 +7,9 @@ import pytest
 import fre.app.remap_pp_components.remap_pp_components as rmp
 
 # Test paths
-CWD = os.getcwd()
-TEST_DIR = Path(f"{CWD}/fre/app/remap_pp_components/tests")
-DATA_DIR = Path(f"{CWD}/fre/app/remap_pp_components/tests/test-data")
+CWD = Path.cwd()
+TEST_DIR = CWD / "fre" / "app" / "remap_pp_components" / "tests"
+DATA_DIR = TEST_DIR / "test-data"
 
 # YAML configuration example file
 YAML_EX = f"{DATA_DIR}/yaml_ex.yaml"


### PR DESCRIPTION
## Describe your changes

Replace the remaining `os.getcwd()` calls under `fre/app` with `Path.cwd()` and simplify the affected test path construction. This also removes the now-unused `os` import from the regrid tests.

Validation:
- Targeted pytest run: 6 passed, 5 skipped, 1 expected xfail
- Pylint on the changed files: 9.32/10

The remaining remap tests require the external `ncgen` and `cylc` executables, which are not available in the local Windows environment.

## Issue ticket number and link (if applicable)
Fixes #943

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [x] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [x] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module

*Note: If you are a code maintainer updating the tag or releasing a new fre-cli version, please use the `release_procedure.md` template. To quickly use this template, open a new pull request, choose your branch, and add `?template=release_procedure.md` to the end of the url.*