### PR TITLE
Replace os.getcwd() usage in fre/make container build scripts (#945)

### DIFF
--- a/fre/make/create_docker_script.py
+++ b/fre/make/create_docker_script.py
@@ -111,15 +111,15 @@ def dockerfile_create(yamlfile: str, platform: tuple[str], target: tuple[str],
                 dockerBuild.writeDockerfileMkmf(c)
 
             dockerBuild.writeRunscript(platform["RUNenv"], platform["containerRun"], tmpDir+"/execrunscript.sh")
-            currDir = os.getcwd()
 
             # create build script for container
             dockerBuild.createBuildScript(platform, skip_format_transfer = no_format_transfer)
+            buildDir = os.path.dirname(dockerBuild.userScriptPath)
 
             former_log_level = fre_logger.level
             fre_logger.setLevel(logging.INFO)
-            fre_logger.info("tmpDir created in " + currDir + "/tmp")
-            fre_logger.info("Dockerfile created in " + currDir)
+            fre_logger.info("tmpDir created in " + os.path.join(buildDir, "tmp"))
+            fre_logger.info("Dockerfile created in " + buildDir)
             fre_logger.info("Container build script created in "+dockerBuild.userScriptPath)
             fre_logger.setLevel(former_log_level)
 

--- a/fre/make/gfdlfremake/buildDocker.py
+++ b/fre/make/gfdlfremake/buildDocker.py
@@ -255,8 +255,8 @@ class container():
                 # Remove it from the original location
                 self.userScript.append(f"rm -f {containerName}.tar {containerName}.sif\n")
 
-        self.userScriptFile = open("createContainer.sh","w")
+        self.userScriptPath = os.path.abspath("createContainer.sh")
+        self.userScriptFile = open(self.userScriptPath,"w")
         self.userScriptFile.writelines(self.userScript)
         self.userScriptFile.close()
-        os.chmod("createContainer.sh", 0o744)
-        self.userScriptPath = os.getcwd()+"/createContainer.sh"
+        os.chmod(self.userScriptPath, 0o744)


### PR DESCRIPTION
## Describe your changes

Removes both os.getcwd() calls in fre/make, following the reasoning in #942:

- fre/make/gfdlfremake/buildDocker.py (createBuildScript): the absolute path of
  createContainer.sh is now computed once with os.path.abspath() and reused for
  open(), os.chmod(), and self.userScriptPath, instead of concatenating
  os.getcwd() + "/createContainer.sh".

- fre/make/create_docker_script.py: currDir = os.getcwd() is removed; the log
  messages now derive the location from dockerBuild.userScriptPath via
  os.path.dirname(), so they report where files were actually written.

No behavior change intended: the build script is still written to the caller's
working directory, as before.

Note: there are additional os.getcwd() calls under fre/make/tests/. I left those
out to keep this PR scoped to the two lines linked in #945 — happy to open a
follow-up PR covering the tests if that's wanted.

This is my first contribution to fre-cli , and any feedback welcome.

## Issue ticket number and link (if applicable)
Fixes #945 

## Checklist before requesting a review

- [ ] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module

Verified both files compile with python -m py_compile; relying on CI for the full test suite.
